### PR TITLE
Fjerner gammel route for samarbeidshistorikk

### DIFF
--- a/src/main/kotlin/no/nav/lydia/ia/sak/IASakService.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/IASakService.kt
@@ -72,7 +72,7 @@ class IASakService(
         }
         return IASakshendelse.fromDto(hendelseDto, rådgiver.navIdent)
             .map { sakshendelse ->
-                val hendelser = iaSakshendelseRepository.hentHendelser(sakshendelse.saksnummer)
+                val hendelser = iaSakshendelseRepository.hentHendelserForSaksnummer(sakshendelse.saksnummer)
                 if (hendelser.isEmpty()) return Either.Left(IASakError.`prøvde å legge til en hendelse på en tom sak`)
                 if (hendelser.last().id != hendelseDto.endretAvHendelseId) return Either.Left(IASakError.`prøvde å legge til en hendelse på en gammel sak`)
                 val sak = IASak.fraHendelser(hendelser)
@@ -89,7 +89,7 @@ class IASakService(
 
     fun hentSaker(orgnummer: String): List<IASak> = iaSakRepository.hentSaker(orgnummer)
 
-    fun hentHendelserForSak(saksnummer: String): List<IASakshendelse> =
-        iaSakshendelseRepository.hentHendelser(saksnummer)
+    fun hentHendelserForSaksnummer(saksnummer: String): List<IASakshendelse> =
+        iaSakshendelseRepository.hentHendelserForSaksnummer(saksnummer)
 
 }

--- a/src/main/kotlin/no/nav/lydia/ia/sak/IASakService.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/IASakService.kt
@@ -87,9 +87,9 @@ class IASakService(
             }
     }
 
-    fun hentSaker(orgnummer: String): List<IASak> = iaSakRepository.hentSaker(orgnummer)
+    fun hentSakerForOrgnummer(orgnummer: String): List<IASak> = iaSakRepository.hentSaker(orgnummer)
 
-    fun hentHendelserForSaksnummer(saksnummer: String): List<IASakshendelse> =
-        iaSakshendelseRepository.hentHendelserForSaksnummer(saksnummer)
+    fun hentHendelserForOrgnummer(orgnr: String): List<IASakshendelse> =
+        iaSakshendelseRepository.hentHendelserForOrgnummer(orgnr = orgnr)
 
 }

--- a/src/main/kotlin/no/nav/lydia/ia/sak/api/IASakRådgiverRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/api/IASakRådgiverRoutes.kt
@@ -1,13 +1,16 @@
 package no.nav.lydia.ia.sak.api
 
 import arrow.core.Either
+import arrow.core.getOrElse
 import arrow.core.right
 import com.github.guepardoapps.kulid.ULID
-import io.ktor.http.*
-import io.ktor.server.application.*
-import io.ktor.server.request.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import no.nav.lydia.AuditLog
 import no.nav.lydia.AuditType
 import no.nav.lydia.FiaRoller
@@ -102,12 +105,26 @@ fun Route.IASak_Rådgiver(
                 IASak.fraHendelser(iaSakService.hentHendelserForSak(it.saksnummer))
             }.right()
         }. also { either ->
-            auditLog.auditloggEither(
-                call = call,
-                either = either,
-                orgnummer = orgnummer,
-                auditType = AuditType.access
-            )
+            if (either.isLeft()) {
+                auditLog.auditloggEither(
+                    call = call,
+                    either = either,
+                    orgnummer = orgnummer,
+                    auditType = AuditType.access,
+                )
+            } else {
+                val iaSaker = either.getOrElse { listOf() }
+                iaSaker.forEach { iaSak ->
+                    auditLog.auditloggEither(
+                        call = call,
+                        either = either,
+                        orgnummer = orgnummer,
+                        auditType = AuditType.access,
+                        saksnummer = iaSak.saksnummer
+                    )
+                }
+            }
+
         }.map { iaSaker ->
             call.respond(iaSaker.tilSamarbeidshistorikk()).right()
         }.mapLeft {

--- a/src/main/kotlin/no/nav/lydia/ia/sak/db/IASakshendelseRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/db/IASakshendelseRepository.kt
@@ -15,7 +15,7 @@ import javax.sql.DataSource
 
 class IASakshendelseRepository(val dataSource: DataSource) {
 
-    fun hentHendelser(saksnummer: String) =
+    fun hentHendelserForSaksnummer(saksnummer: String) =
         using(sessionOf(dataSource)) { session ->
             session.run(
                 queryOf(
@@ -42,14 +42,14 @@ class IASakshendelseRepository(val dataSource: DataSource) {
                     GROUP BY aarsak_enum, id, type, orgnr, opprettet_av, saksnummer, opprettet
                     ORDER BY id ASC
                     """.trimIndent(),
-                        mapOf(
-                            "saksnummer" to saksnummer
-                        )
+                    mapOf(
+                        "saksnummer" to saksnummer
                     )
+                )
                     .map(this::mapRow).asList
             )
         }
-
+    
     fun lagreHendelse(hendelse: IASakshendelse) =
         using(sessionOf(dataSource)) { session ->
             session.run(

--- a/src/test/kotlin/no/nav/lydia/container/audit/AuditLogTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/audit/AuditLogTest.kt
@@ -140,7 +140,7 @@ class AuditLogTest {
     fun `auditlogger uthenting av hendelser på IA-sak på et gyldig saksnummer`() {
         val orgnummer = nyttOrgnummer()
         val sak = SakHelper.opprettSakForVirksomhet(orgnummer = orgnummer, token = mockOAuth2Server.superbruker1.token)
-        SakHelper.hentSamarbeidsHistorikkRespons(orgnummer = orgnummer, token = mockOAuth2Server.superbruker1.token).also {
+        SakHelper.hentSamarbeidshistorikkRespons(orgnummer = orgnummer, token = mockOAuth2Server.superbruker1.token).also {
             lydiaApiContainer shouldContainLog auditLog(
                 request = it.first,
                 navIdent = mockOAuth2Server.superbruker1.navIdent,
@@ -150,7 +150,7 @@ class AuditLogTest {
                 saksnummer = sak.saksnummer
             )
         }
-        SakHelper.hentSamarbeidsHistorikkRespons(orgnummer = orgnummer, token = mockOAuth2Server.brukerUtenTilgangsrolle.token)
+        SakHelper.hentSamarbeidshistorikkRespons(orgnummer = orgnummer, token = mockOAuth2Server.brukerUtenTilgangsrolle.token)
             .also {
                 lydiaApiContainer shouldContainLog auditLog(
                     request = it.first,

--- a/src/test/kotlin/no/nav/lydia/container/audit/AuditLogTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/audit/AuditLogTest.kt
@@ -155,7 +155,7 @@ class AuditLogTest {
                 lydiaApiContainer shouldContainLog auditLog(
                     request = it.first,
                     navIdent = mockOAuth2Server.brukerUtenTilgangsrolle.navIdent,
-                    orgnummer = orgnummer, // Vi auditlogger ikke hvilket orgnummer man ikke hadde tilgang til
+                    orgnummer = orgnummer,
                     auditType = AuditType.access,
                     tillat = Tillat.Nei,
                 )

--- a/src/test/kotlin/no/nav/lydia/container/ia/sak/IASakApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/sak/IASakApiTest.kt
@@ -14,7 +14,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.ktor.http.HttpStatusCode
-import no.nav.lydia.helper.SakHelper.Companion.hentHendelserPåSakRespons
+import no.nav.lydia.helper.SakHelper.Companion.hentSamarbeidshistorikkForOrgnrRespons
 import no.nav.lydia.helper.SakHelper.Companion.hentSaker
 import no.nav.lydia.helper.SakHelper.Companion.hentSakerRespons
 import no.nav.lydia.helper.SakHelper.Companion.hentSamarbeidshistorikk
@@ -27,7 +27,6 @@ import no.nav.lydia.helper.SakHelper.Companion.opprettSakForVirksomhet
 import no.nav.lydia.helper.SakHelper.Companion.opprettSakForVirksomhetRespons
 import no.nav.lydia.helper.SakHelper.Companion.toJson
 import no.nav.lydia.helper.StatistikkHelper.Companion.hentSykefravær
-import no.nav.lydia.helper.TestContainerHelper
 import no.nav.lydia.helper.TestContainerHelper.Companion.oauth2ServerContainer
 import no.nav.lydia.helper.TestVirksomhet
 import no.nav.lydia.helper.VirksomhetHelper
@@ -60,7 +59,6 @@ import kotlin.test.assertTrue
 
 class IASakApiTest {
     val mockOAuth2Server = oauth2ServerContainer
-    val postgresContainer = TestContainerHelper.postgresContainer
 
     @Test
     fun `skal kunne sette en virksomhet i kontaktes status`() {
@@ -205,20 +203,20 @@ class IASakApiTest {
                 token = mockOAuth2Server.brukerUtenTilgangsrolle.token
             ).statuskode() shouldBe 403
 
-            hentHendelserPåSakRespons(
-                saksnummer = sak.saksnummer,
+            hentSamarbeidshistorikkForOrgnrRespons(
+                orgnr = orgnummer,
                 token = mockOAuth2Server.lesebruker.token
             ).statuskode() shouldBe 200
-            hentHendelserPåSakRespons(
-                saksnummer = sak.saksnummer,
+            hentSamarbeidshistorikkForOrgnrRespons(
+                orgnr = orgnummer,
                 token = mockOAuth2Server.saksbehandler1.token
             ).statuskode() shouldBe 200
-            hentHendelserPåSakRespons(
-                saksnummer = sak.saksnummer,
+            hentSamarbeidshistorikkForOrgnrRespons(
+                orgnr = orgnummer,
                 token = mockOAuth2Server.superbruker1.token
             ).statuskode() shouldBe 200
-            hentHendelserPåSakRespons(
-                saksnummer = sak.saksnummer,
+            hentSamarbeidshistorikkForOrgnrRespons(
+                orgnr = orgnummer,
                 token = mockOAuth2Server.brukerUtenTilgangsrolle.token
             ).statuskode() shouldBe 403
         }
@@ -246,20 +244,20 @@ class IASakApiTest {
                     token = mockOAuth2Server.brukerUtenTilgangsrolle.token
                 ).statuskode() shouldBe 403
 
-                hentHendelserPåSakRespons(
-                    saksnummer = sak.saksnummer,
+                hentSamarbeidshistorikkForOrgnrRespons(
+                    orgnr = orgnummer,
                     token = mockOAuth2Server.lesebruker.token
                 ).statuskode() shouldBe 200
-                hentHendelserPåSakRespons(
-                    saksnummer = sak.saksnummer,
+                hentSamarbeidshistorikkForOrgnrRespons(
+                    orgnr = orgnummer,
                     token = mockOAuth2Server.saksbehandler1.token
                 ).statuskode() shouldBe 200
-                hentHendelserPåSakRespons(
-                    saksnummer = sak.saksnummer,
+                hentSamarbeidshistorikkForOrgnrRespons(
+                    orgnr = orgnummer,
                     token = mockOAuth2Server.superbruker1.token
                 ).statuskode() shouldBe 200
-                hentHendelserPåSakRespons(
-                    saksnummer = sak.saksnummer,
+                hentSamarbeidshistorikkForOrgnrRespons(
+                    orgnr = orgnummer,
                     token = mockOAuth2Server.brukerUtenTilgangsrolle.token
                 ).statuskode() shouldBe 403
             }
@@ -275,8 +273,8 @@ class IASakApiTest {
                         orgnummer = orgnummer,
                         token = mockOAuth2Server.saksbehandler1.token
                     ).statuskode() shouldBe 200
-                    hentHendelserPåSakRespons(
-                        saksnummer = sak.saksnummer,
+                    hentSamarbeidshistorikkForOrgnrRespons(
+                        orgnr = orgnummer,
                         token = mockOAuth2Server.saksbehandler1.token
                     ).statuskode() shouldBe 200
                 }
@@ -289,8 +287,8 @@ class IASakApiTest {
                         orgnummer = orgnummer,
                         token = mockOAuth2Server.superbruker1.token
                     ).statuskode() shouldBe 200
-                    hentHendelserPåSakRespons(
-                        saksnummer = sak.saksnummer,
+                    hentSamarbeidshistorikkForOrgnrRespons(
+                        orgnr = orgnummer,
                         token = mockOAuth2Server.superbruker1.token
                     ).statuskode() shouldBe 200
                 }

--- a/src/test/kotlin/no/nav/lydia/container/ia/sak/IASakApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/sak/IASakApiTest.kt
@@ -17,7 +17,7 @@ import io.ktor.http.HttpStatusCode
 import no.nav.lydia.helper.SakHelper.Companion.hentHendelserPåSakRespons
 import no.nav.lydia.helper.SakHelper.Companion.hentSaker
 import no.nav.lydia.helper.SakHelper.Companion.hentSakerRespons
-import no.nav.lydia.helper.SakHelper.Companion.hentSamarbeidsHistorikk
+import no.nav.lydia.helper.SakHelper.Companion.hentSamarbeidshistorikk
 import no.nav.lydia.helper.SakHelper.Companion.nyHendelse
 import no.nav.lydia.helper.SakHelper.Companion.nyHendelsePåSak
 import no.nav.lydia.helper.SakHelper.Companion.nyHendelsePåSakMedRespons
@@ -337,12 +337,13 @@ class IASakApiTest {
                     payload = valgtÅrsak.toJson()
                 )
             val alleHendelsesTyper = listOf(
+                OPPRETT_SAK_FOR_VIRKSOMHET,
                 VIRKSOMHET_VURDERES,
                 TA_EIERSKAP_I_SAK,
                 VIRKSOMHET_SKAL_KONTAKTES,
                 VIRKSOMHET_ER_IKKE_AKTUELL
             )
-            hentSamarbeidsHistorikk(orgnummer, mockOAuth2Server.superbruker1.token).also { sakshistorikkForVirksomhet ->
+            hentSamarbeidshistorikk(orgnummer, mockOAuth2Server.superbruker1.token).also { sakshistorikkForVirksomhet ->
                 val historikkForSak = sakshistorikkForVirksomhet.find { it.saksnummer == sakIkkeAktuell.saksnummer }
                 historikkForSak shouldNotBe null
                 historikkForSak!!.sakshendelser.map { it.hendelsestype } shouldContainExactly alleHendelsesTyper
@@ -369,16 +370,18 @@ class IASakApiTest {
                 payload = valgtÅrsak.toJson()
             )
 
-        hentSamarbeidsHistorikk(orgnummer = orgnummer).also { samarbeidshistorikk ->
+        hentSamarbeidshistorikk(orgnummer = orgnummer).also { samarbeidshistorikk ->
             samarbeidshistorikk shouldHaveSize 1
             val sakshistorikk = samarbeidshistorikk.first()
             sakshistorikk.sakshendelser.map { it.status } shouldContainExactly listOf(
+                IAProsessStatus.NY,
                 IAProsessStatus.VURDERES,
                 IAProsessStatus.VURDERES,
                 IAProsessStatus.KONTAKTES,
                 IAProsessStatus.IKKE_AKTUELL
             )
             sakshistorikk.sakshendelser.map { it.hendelsestype } shouldContainExactly listOf(
+                OPPRETT_SAK_FOR_VIRKSOMHET,
                 VIRKSOMHET_VURDERES,
                 TA_EIERSKAP_I_SAK,
                 VIRKSOMHET_SKAL_KONTAKTES,
@@ -551,7 +554,7 @@ class IASakApiTest {
                         begrunnelser = begrunnelser
                     ).toJson()
                 )
-            hentSamarbeidsHistorikk(orgnummer, mockOAuth2Server.superbruker1.token).first().sakshendelser
+            hentSamarbeidshistorikk(orgnummer, mockOAuth2Server.superbruker1.token).first().sakshendelser
                 .forAtLeastOne { hendelseOppsummering ->
                     hendelseOppsummering.hendelsestype shouldBe VIRKSOMHET_ER_IKKE_AKTUELL
                     hendelseOppsummering.tidspunktForSnapshot shouldBe sakIkkeAktuell.endretTidspunkt

--- a/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
@@ -134,23 +134,13 @@ class SakHelper {
                 .responseObject<List<SakshistorikkDto>>(localDateTimeTypeAdapter)
 
 
-        fun hentHendelserPåSakRespons(
-            saksnummer: String,
+        fun hentSamarbeidshistorikkForOrgnrRespons(
+            orgnr: String,
             token: String = oauth2ServerContainer.saksbehandler1.token
         ) =
-            lydiaApiContainer.performGet("$IA_SAK_RADGIVER_PATH/$SAMARBEIDSHISTORIKK_PATH/$saksnummer")
+            lydiaApiContainer.performGet("$IA_SAK_RADGIVER_PATH/$SAMARBEIDSHISTORIKK_PATH/$orgnr")
                 .authentication().bearer(token = token)
                 .responseObject<List<IASakshendelseOppsummeringDto>>(localDateTimeTypeAdapter)
-
-        fun hentHendelserPåSak(
-            saksnummer: String,
-            token: String = oauth2ServerContainer.saksbehandler1.token
-        ) =
-            hentHendelserPåSakRespons(saksnummer = saksnummer, token = token).third.fold(
-                success = { respons -> respons },
-                failure = {
-                    fail(it.message)
-                })
 
         fun opprettSakForVirksomhetRespons(
             orgnummer: String,
@@ -190,7 +180,7 @@ class SakHelper {
             payload: String? = null
         ): ResponseResultOf<IASakDto> {
             val request = nyHendelsePåSakRequest(token, sak, hendelsestype, payload)
-            return request.responseObject<IASakDto>(localDateTimeTypeAdapter)
+            return request.responseObject(localDateTimeTypeAdapter)
         }
 
         fun nyHendelsePåSakRequest(
@@ -199,7 +189,7 @@ class SakHelper {
             hendelsestype: SaksHendelsestype,
             payload: String?
         ): Request {
-            val request = lydiaApiContainer.performPost("$IA_SAK_RADGIVER_PATH/$SAK_HENDELSE_SUB_PATH")
+            return lydiaApiContainer.performPost("$IA_SAK_RADGIVER_PATH/$SAK_HENDELSE_SUB_PATH")
                 .authentication().bearer(token)
                 .jsonBody(
                     IASakshendelseDto(
@@ -211,7 +201,6 @@ class SakHelper {
                     ),
                     localDateTimeTypeAdapter
                 )
-            return request
         }
 
 

--- a/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
@@ -14,9 +14,14 @@ import no.nav.lydia.helper.TestContainerHelper.Companion.lydiaApiContainer
 import no.nav.lydia.helper.TestContainerHelper.Companion.oauth2ServerContainer
 import no.nav.lydia.helper.TestContainerHelper.Companion.performGet
 import no.nav.lydia.helper.TestContainerHelper.Companion.performPost
-import no.nav.lydia.ia.sak.api.*
-import no.nav.lydia.ia.sak.domene.SaksHendelsestype
+import no.nav.lydia.ia.sak.api.IASakDto
+import no.nav.lydia.ia.sak.api.IASakshendelseDto
+import no.nav.lydia.ia.sak.api.IASakshendelseOppsummeringDto
+import no.nav.lydia.ia.sak.api.IA_SAK_RADGIVER_PATH
+import no.nav.lydia.ia.sak.api.SAK_HENDELSE_SUB_PATH
+import no.nav.lydia.ia.sak.api.SAMARBEIDSHISTORIKK_PATH
 import no.nav.lydia.ia.sak.api.SakshistorikkDto
+import no.nav.lydia.ia.sak.domene.SaksHendelsestype
 import no.nav.lydia.ia.årsak.domene.ValgtÅrsak
 import no.nav.lydia.integrasjoner.brreg.BrregDownloader
 import no.nav.lydia.integrasjoner.ssb.NæringsDownloader
@@ -115,20 +120,25 @@ class SakHelper {
             orgnummer: String,
             token: String = oauth2ServerContainer.saksbehandler1.token
         ) =
+            hentSamarbeidsHistorikkRespons(orgnummer, token).third.fold(
+                success = { respons -> respons },
+                failure = { fail(it.message) }
+            )
+
+        fun hentSamarbeidsHistorikkRespons(
+            orgnummer: String,
+            token: String = oauth2ServerContainer.saksbehandler1.token
+        ) =
             lydiaApiContainer.performGet("$IA_SAK_RADGIVER_PATH/$SAMARBEIDSHISTORIKK_PATH/$orgnummer")
                 .authentication().bearer(token = token)
-                .responseObject<List<SakshistorikkDto>>(localDateTimeTypeAdapter).third
-                .fold(
-                    success = { respons -> respons },
-                    failure = { fail(it.message) }
-                )
+                .responseObject<List<SakshistorikkDto>>(localDateTimeTypeAdapter)
 
 
         fun hentHendelserPåSakRespons(
             saksnummer: String,
             token: String = oauth2ServerContainer.saksbehandler1.token
         ) =
-            lydiaApiContainer.performGet("$IA_SAK_RADGIVER_PATH/$SAK_HENDELSER_SUB_PATH/$saksnummer")
+            lydiaApiContainer.performGet("$IA_SAK_RADGIVER_PATH/$SAMARBEIDSHISTORIKK_PATH/$saksnummer")
                 .authentication().bearer(token = token)
                 .responseObject<List<IASakshendelseOppsummeringDto>>(localDateTimeTypeAdapter)
 

--- a/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
@@ -116,16 +116,16 @@ class SakHelper {
                 .authentication().bearer(token = token)
                 .responseObject<List<IASakDto>>(localDateTimeTypeAdapter)
 
-        fun hentSamarbeidsHistorikk(
+        fun hentSamarbeidshistorikk(
             orgnummer: String,
             token: String = oauth2ServerContainer.saksbehandler1.token
         ) =
-            hentSamarbeidsHistorikkRespons(orgnummer, token).third.fold(
+            hentSamarbeidshistorikkRespons(orgnummer, token).third.fold(
                 success = { respons -> respons },
                 failure = { fail(it.message) }
             )
 
-        fun hentSamarbeidsHistorikkRespons(
+        fun hentSamarbeidshistorikkRespons(
             orgnummer: String,
             token: String = oauth2ServerContainer.saksbehandler1.token
         ) =


### PR DESCRIPTION
- Første run for å fjerne gammel route, gjenstår fortsatt noen tester som har endret logikk som følge av refaktoreringen
- Fjerner ubrukt endepunkt i IASakRådgiverRoutes
- Fikser test som feilet pga samarbeidshistorikk ikke inkluderte opprettelseshendelsen
- Fiks: bruk orgnr i stedet for saksnummer i path som forventer saksnummer
- Henter hendelser på orgnummer i stedet for saksnummer
