### PR TITLE
Hente statistikk over siste 4 kvartaler

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,7 +41,32 @@ jobs:
         cluster: [dev, prod]
     name: "Deploy app to ${{ matrix.cluster }}"
     needs: "build"
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/konsumere-meldinger-fra-statistikk-per-kategori'
+    if: github.ref == 'refs/heads/main'
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - name: "Deploy application to ${{ matrix.cluster }}"
+        uses: "nais/deploy/actions/deploy@v1"
+        env:
+          "APIKEY": "${{ secrets.NAIS_DEPLOY_APIKEY }}"
+          "CLUSTER": "${{ matrix.cluster }}-gcp"
+          "RESOURCE": ".nais/nais.yaml"
+          "VARS": ".nais/${{ matrix.cluster }}.yaml"
+      - name: "Deploy topics to ${{ matrix.cluster }}"
+        uses: "nais/deploy/actions/deploy@master"
+        env:
+          APIKEY: "${{ secrets.NAIS_DEPLOY_APIKEY }}"
+          CLUSTER: "${{ matrix.cluster }}-gcp"
+          RESOURCE: ".nais/topics/ia-sak-hendelse-topic.yaml,.nais/topics/ia-sak-topic.yaml"
+          VARS: ".nais/${{ matrix.cluster }}.yaml"
+
+  deploy-dev-branch:
+    strategy:
+      matrix:
+        cluster: [ dev ]
+    name: "Deploy app to ${{ matrix.cluster }}"
+    needs: "build"
+    if: github.ref == 'refs/heads/hente-statistikk-over-siste-4-kvartaler'
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,7 +66,7 @@ jobs:
         cluster: [ dev ]
     name: "Deploy app to ${{ matrix.cluster }}"
     needs: "build"
-    if: github.ref == 'refs/heads/hente-statistikk-over-siste-4-kvartaler--IKKE-DEPLOY-ENDA'
+    if: github.ref == 'refs/heads/hente-statistikk-over-siste-4-kvartaler'
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,7 +66,7 @@ jobs:
         cluster: [ dev ]
     name: "Deploy app to ${{ matrix.cluster }}"
     needs: "build"
-    if: github.ref == 'refs/heads/hente-statistikk-over-siste-4-kvartaler'
+    if: github.ref == 'refs/heads/hente-statistikk-over-siste-4-kvartaler--IKKE-DEPLOY-ENDA'
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"

--- a/src/main/kotlin/no/nav/lydia/App.kt
+++ b/src/main/kotlin/no/nav/lydia/App.kt
@@ -55,6 +55,7 @@ import no.nav.lydia.integrasjoner.ssb.NæringsDownloader
 import no.nav.lydia.integrasjoner.ssb.NæringsRepository
 import no.nav.lydia.integrasjoner.ssb.næringsImport
 import no.nav.lydia.sykefraversstatistikk.SykefraversstatistikkRepository
+import no.nav.lydia.sykefraversstatistikk.SykefraværsstatistikkSiste4KvartalRepository
 import no.nav.lydia.sykefraversstatistikk.SykefraværsstatistikkService
 import no.nav.lydia.sykefraversstatistikk.api.SYKEFRAVERSSTATISTIKK_PATH
 import no.nav.lydia.sykefraversstatistikk.api.geografi.GeografiService
@@ -88,6 +89,7 @@ fun startLydiaBackend() {
         sykefraversstatistikkRepository = SykefraversstatistikkRepository(
             dataSource = dataSource
         ),
+        sykefraværsstatistikkSiste4KvartalRepository = SykefraværsstatistikkSiste4KvartalRepository(dataSource = dataSource)
     )
     statistikkConsumer(
         kafka = naisEnv.kafka,
@@ -153,7 +155,7 @@ fun Application.lydiaRestApi(
     install(CallLogging) {
         callIdMdc("requestId")
         disableDefaultColors()
-        filter {call ->
+        filter { call ->
             listOf(SYKEFRAVERSSTATISTIKK_PATH, IA_SAK_RADGIVER_PATH, VIRKSOMHET_PATH, VEILEDERE_PATH).any() {
                 call.request.path().startsWith(it)
             }
@@ -205,6 +207,7 @@ fun Application.lydiaRestApi(
     val sykefraværsstatistikkService =
         SykefraværsstatistikkService(
             sykefraversstatistikkRepository = SykefraversstatistikkRepository(dataSource = dataSource),
+            sykefraværsstatistikkSiste4KvartalRepository = SykefraværsstatistikkSiste4KvartalRepository(dataSource = dataSource)
         )
     val grunnlagRepository = GrunnlagRepository(dataSource = dataSource)
     val årsakRepository = ÅrsakRepository(dataSource = dataSource)

--- a/src/main/kotlin/no/nav/lydia/UnleashKlient.kt
+++ b/src/main/kotlin/no/nav/lydia/UnleashKlient.kt
@@ -30,9 +30,12 @@ object UnleashKlient {
     fun isEnabled(toggleKey: String) = unleash.isEnabled(toggleKey, false)
     fun skruPå(toggleKey: String) = (unleash as FakeUnleash).enable(toggleKey)
     fun skruAv(toggleKey: String) = (unleash as FakeUnleash).disable(toggleKey)
+
+    inline fun skalHenteSiste4Kvartal() = isEnabled(UnleashToggleKeys.henteSiste4Kvartal)
 }
 
 object UnleashToggleKeys {
+    val henteSiste4Kvartal = "pia.hente-siste-4-kvartal"
 }
 
 class ClusterStrategy(val miljø: NaisEnvironment.Companion.Environment) : Strategy {

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
@@ -298,9 +298,9 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
         tmpNæringTabell: String,
         søkeparametere: Søkeparametere,
     ) = """
-        FROM sykefravar_statistikk_virksomhet_siste_4_kvartal AS statistikk_siste4
-        join sykefravar_statistikk_virksomhet AS statistikk USING (orgnr)
+        FROM sykefravar_statistikk_virksomhet AS statistikk
         JOIN virksomhet USING (orgnr)
+        LEFT JOIN sykefravar_statistikk_virksomhet_siste_4_kvartal AS statistikk_siste4 USING (orgnr)
         LEFT JOIN ia_sak ON (
             (ia_sak.orgnr = statistikk.orgnr) AND
             ia_sak.endret = (select max(endret) from ia_sak iasak2 where iasak2.orgnr = statistikk.orgnr)
@@ -370,9 +370,9 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
                         ia_sak.status,
                         ia_sak.eid_av,
                         ia_sak.endret
-                  FROM sykefravar_statistikk_virksomhet_siste_4_kvartal AS statistikk_siste4
-                  JOIN sykefravar_statistikk_virksomhet AS statistikk USING (orgnr)
+                  FROM sykefravar_statistikk_virksomhet AS statistikk
                   JOIN virksomhet USING (orgnr)
+                  LEFT JOIN sykefravar_statistikk_virksomhet_siste_4_kvartal AS statistikk_siste4 USING (orgnr)
                   LEFT JOIN ia_sak USING(orgnr)
                   WHERE (statistikk.orgnr = :orgnr)
                 """.trimIndent(),

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
@@ -159,11 +159,11 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
                         statistikk.arstall,
                         statistikk.kvartal,
                         statistikk.antall_personer,
-                        statistikk.tapte_dagsverk,
-                        statistikk.mulige_dagsverk,
-                        statistikk.sykefraversprosent,
-                        statistikk.maskert,
-                        statistikk.opprettet,
+                        statistikk_siste4.tapte_dagsverk,
+                        statistikk_siste4.mulige_dagsverk,
+                        statistikk_siste4.prosent,
+                        statistikk_siste4.maskert,
+                        statistikk_siste4.sist_endret,
                         ia_sak.status,
                         ia_sak.eid_av,
                         ia_sak.endret
@@ -183,11 +183,11 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
                         statistikk.arstall,
                         statistikk.kvartal,
                         statistikk.antall_personer,
-                        statistikk.tapte_dagsverk,
-                        statistikk.mulige_dagsverk,
-                        statistikk.sykefraversprosent,
-                        statistikk.maskert,
-                        statistikk.opprettet,
+                        statistikk_siste4.tapte_dagsverk,
+                        statistikk_siste4.mulige_dagsverk,
+                        statistikk_siste4.prosent,
+                        statistikk_siste4.maskert,
+                        statistikk_siste4.sist_endret,
                         ia_sak.status,
                         ia_sak.eid_av,
                         ia_sak.endret
@@ -270,7 +270,8 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
         tmpNæringTabell: String,
         søkeparametere: Søkeparametere,
     ) = """
-        FROM sykefravar_statistikk_virksomhet AS statistikk
+        FROM sykefravar_statistikk_virksomhet_siste_4_kvartal AS statistikk_siste4
+        join sykefravar_statistikk_virksomhet AS statistikk USING (orgnr)
         JOIN virksomhet USING (orgnr)
         LEFT JOIN ia_sak ON (
             (ia_sak.orgnr = statistikk.orgnr) AND
@@ -311,8 +312,8 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
         } ?: ""
     }
                         
-        ${søkeparametere.sykefraværsprosentFra?.let { " AND statistikk.sykefraversprosent >= $it " } ?: ""}
-        ${søkeparametere.sykefraværsprosentTil?.let { " AND statistikk.sykefraversprosent <= $it " } ?: ""}
+        ${søkeparametere.sykefraværsprosentFra?.let { " AND statistikk_siste4.prosent >= $it " } ?: ""}
+        ${søkeparametere.sykefraværsprosentTil?.let { " AND statistikk_siste4.prosent <= $it " } ?: ""}
         
         ${søkeparametere.ansatteFra?.let { " AND statistikk.antall_personer >= $it " } ?: ""}
         ${søkeparametere.ansatteTil?.let { " AND statistikk.antall_personer <= $it " } ?: ""}
@@ -325,22 +326,23 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
             val query = queryOf(
                 statement = """
                     SELECT
-                        statistikk.orgnr,
+                        statistikk_siste4.orgnr,
                         virksomhet.navn,
                         virksomhet.kommune,
                         virksomhet.kommunenummer,
                         statistikk.arstall,
                         statistikk.kvartal,
                         statistikk.antall_personer,
-                        statistikk.tapte_dagsverk,
-                        statistikk.mulige_dagsverk,
-                        statistikk.sykefraversprosent,
-                        statistikk.maskert,
-                        statistikk.opprettet,
+                        statistikk_siste4.tapte_dagsverk,
+                        statistikk_siste4.mulige_dagsverk,
+                        statistikk_siste4.prosent,
+                        statistikk_siste4.maskert,
+                        statistikk_siste4.sist_endret,
                         ia_sak.status,
                         ia_sak.eid_av,
                         ia_sak.endret
-                  FROM sykefravar_statistikk_virksomhet AS statistikk
+                  FROM sykefravar_statistikk_virksomhet_siste_4_kvartal AS statistikk_siste4
+                  JOIN sykefravar_statistikk_virksomhet AS statistikk USING (orgnr)
                   JOIN virksomhet USING (orgnr)
                   LEFT JOIN ia_sak USING(orgnr)
                   WHERE (statistikk.orgnr = :orgnr)
@@ -363,9 +365,9 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
             antallPersoner = row.double("antall_personer"),
             tapteDagsverk = row.double("tapte_dagsverk"),
             muligeDagsverk = row.double("mulige_dagsverk"),
-            sykefraversprosent = row.double("sykefraversprosent"),
+            sykefraversprosent = row.double("prosent"),
             maskert = row.boolean("maskert"),
-            opprettet = row.localDateTime("opprettet"),
+            opprettet = row.localDateTime("sist_endret"),
             status = row.stringOrNull("status")?.let {
                 IAProsessStatus.valueOf(it)
             },

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
@@ -3,13 +3,25 @@ package no.nav.lydia.sykefraversstatistikk
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import kotlinx.datetime.toKotlinLocalDate
-import kotliquery.*
+import kotliquery.Row
+import kotliquery.TransactionalSession
+import kotliquery.queryOf
+import kotliquery.sessionOf
+import kotliquery.using
+import no.nav.lydia.UnleashKlient.skalHenteSiste4Kvartal
 import no.nav.lydia.ia.sak.domene.IAProsessStatus
 import no.nav.lydia.ia.sak.domene.IAProsessStatus.IKKE_AKTIV
 import no.nav.lydia.sykefraversstatistikk.api.Søkeparametere
 import no.nav.lydia.sykefraversstatistikk.api.geografi.Kommune
 import no.nav.lydia.sykefraversstatistikk.domene.SykefraversstatistikkVirksomhet
-import no.nav.lydia.sykefraversstatistikk.import.*
+import no.nav.lydia.sykefraversstatistikk.import.BehandletImportStatistikk
+import no.nav.lydia.sykefraversstatistikk.import.BehandletKvartalsvisSykefraværsstatistikk
+import no.nav.lydia.sykefraversstatistikk.import.BehandletLandSykefraværsstatistikk
+import no.nav.lydia.sykefraversstatistikk.import.BehandletNæringSykefraværsstatistikk
+import no.nav.lydia.sykefraversstatistikk.import.BehandletNæringsundergruppeSykefraværsstatistikk
+import no.nav.lydia.sykefraversstatistikk.import.BehandletSektorSykefraværsstatistikk
+import no.nav.lydia.sykefraversstatistikk.import.BehandletVirksomhetSykefraværsstatistikk
+import no.nav.lydia.sykefraversstatistikk.import.SykefraversstatistikkPerKategoriImportDto
 import no.nav.lydia.virksomhet.domene.VirksomhetStatus
 import javax.sql.DataSource
 
@@ -139,9 +151,25 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
                 )
         """.trimIndent()
 
+    private fun getTabellOgKolonneNavn(skalHentePåSiste4Kvartal: Boolean, feltnavn: String): String {
+        return when(feltnavn) {
+            "tapte_dagsverk" -> if(skalHentePåSiste4Kvartal) "statistikk_siste4.tapte_dagsverk" else "statistikk.tapte_dagsverk"
+            "mulige_dagsverk" -> if(skalHentePåSiste4Kvartal) "statistikk_siste4.mulige_dagsverk" else "statistikk.mulige_dagsverk"
+            "prosent" -> if(skalHentePåSiste4Kvartal) "statistikk_siste4.prosent" else "statistikk.sykefraversprosent"
+            "maskert" -> if(skalHentePåSiste4Kvartal) "statistikk_siste4.maskert" else "statistikk.maskert"
+            "sist_endret" -> if(skalHentePåSiste4Kvartal) "statistikk_siste4.sist_endret" else "statistikk.opprettet"
+            else -> {
+                throw RuntimeException("Ukjent felt $feltnavn")
+            }
+        }
+
+
+    }
+
     fun hentSykefravær(
         søkeparametere: Søkeparametere,
     ) = using(sessionOf(dataSource)) { session ->
+        val skalHentePåSiste4Kvartal = skalHenteSiste4Kvartal()
         val næringsgrupperMedBransjer = søkeparametere.næringsgrupperMedBransjer()
         val tmpKommuneTabell = "kommuner"
         val tmpNæringTabell = "naringer"
@@ -159,11 +187,11 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
                         statistikk.arstall,
                         statistikk.kvartal,
                         statistikk.antall_personer,
-                        statistikk_siste4.tapte_dagsverk,
-                        statistikk_siste4.mulige_dagsverk,
-                        statistikk_siste4.prosent,
-                        statistikk_siste4.maskert,
-                        statistikk_siste4.sist_endret,
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "tapte_dagsverk")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "mulige_dagsverk")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "prosent")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "maskert")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "sist_endret")},
                         ia_sak.status,
                         ia_sak.eid_av,
                         ia_sak.endret
@@ -183,15 +211,15 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
                         statistikk.arstall,
                         statistikk.kvartal,
                         statistikk.antall_personer,
-                        statistikk_siste4.tapte_dagsverk,
-                        statistikk_siste4.mulige_dagsverk,
-                        statistikk_siste4.prosent,
-                        statistikk_siste4.maskert,
-                        statistikk_siste4.sist_endret,
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "tapte_dagsverk")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "mulige_dagsverk")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "prosent")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "maskert")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "sist_endret")},
                         ia_sak.status,
                         ia_sak.eid_av,
                         ia_sak.endret
-                    ${søkeparametere.sorteringsnøkkel.tilOrderBy()} ${søkeparametere.sorteringsretning} NULLS LAST
+                    ${søkeparametere.sorteringsnøkkel.tilOrderBy(skalHentePåSiste4Kvartal)} ${søkeparametere.sorteringsretning} NULLS LAST
                     LIMIT ${søkeparametere.virksomheterPerSide()}
                     OFFSET ${søkeparametere.offset()}
                 """.trimIndent()
@@ -322,6 +350,7 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
 
 
     fun hentSykefraværForVirksomhet(orgnr: String): List<SykefraversstatistikkVirksomhet> {
+        val skalHentePåSiste4Kvartal = skalHenteSiste4Kvartal()
         return using(sessionOf(dataSource)) { session ->
             val query = queryOf(
                 statement = """
@@ -333,11 +362,11 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
                         statistikk.arstall,
                         statistikk.kvartal,
                         statistikk.antall_personer,
-                        statistikk_siste4.tapte_dagsverk,
-                        statistikk_siste4.mulige_dagsverk,
-                        statistikk_siste4.prosent,
-                        statistikk_siste4.maskert,
-                        statistikk_siste4.sist_endret,
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "tapte_dagsverk")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "mulige_dagsverk")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "prosent")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "maskert")},
+                        ${getTabellOgKolonneNavn(skalHentePåSiste4Kvartal, "sist_endret")},
                         ia_sak.status,
                         ia_sak.eid_av,
                         ia_sak.endret
@@ -365,9 +394,9 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
             antallPersoner = row.double("antall_personer"),
             tapteDagsverk = row.double("tapte_dagsverk"),
             muligeDagsverk = row.double("mulige_dagsverk"),
-            sykefraversprosent = row.double("prosent"),
+            sykefraversprosent = if (skalHenteSiste4Kvartal()) row.double("prosent") else row.double("sykefraversprosent"),
             maskert = row.boolean("maskert"),
-            opprettet = row.localDateTime("sist_endret"),
+            opprettet = if (skalHenteSiste4Kvartal()) row.localDateTime("sist_endret") else row.localDateTime("opprettet"),
             status = row.stringOrNull("status")?.let {
                 IAProsessStatus.valueOf(it)
             },

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
@@ -19,6 +19,7 @@ import java.time.LocalDate.now
 
 class SykefraværsstatistikkService(
     val sykefraversstatistikkRepository: SykefraversstatistikkRepository,
+    val sykefraværsstatistikkSiste4KvartalRepository: SykefraværsstatistikkSiste4KvartalRepository,
 ) {
     val log = LoggerFactory.getLogger(this.javaClass)
 
@@ -47,11 +48,10 @@ class SykefraværsstatistikkService(
         søkeparametere: Søkeparametere
     ): List<SykefraversstatistikkVirksomhet> {
         val start = System.currentTimeMillis()
-        var sykefravær: List<SykefraversstatistikkVirksomhet>
-        if (UnleashKlient.skalHenteSiste4Kvartal()) {
-            TODO()
+        val sykefravær =  if (UnleashKlient.skalHenteSiste4Kvartal()) {
+            sykefraværsstatistikkSiste4KvartalRepository.hentSykefravær(søkeparametere = søkeparametere)
         } else {
-            sykefravær = sykefraversstatistikkRepository.hentSykefravær(søkeparametere = søkeparametere)
+            sykefraversstatistikkRepository.hentSykefravær(søkeparametere = søkeparametere)
         }
 
         log.info("Brukte ${System.currentTimeMillis() - start} ms på å hente statistikk for virksomheter.")

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
@@ -5,6 +5,7 @@ import arrow.core.rightIfNotNull
 import io.ktor.http.*
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toKotlinLocalDate
+import no.nav.lydia.UnleashKlient
 import no.nav.lydia.ia.sak.api.Feil
 import no.nav.lydia.ia.sak.domene.ANTALL_DAGER_FØR_SAK_LÅSES
 import no.nav.lydia.ia.sak.domene.IAProsessStatus
@@ -46,7 +47,12 @@ class SykefraværsstatistikkService(
         søkeparametere: Søkeparametere
     ): List<SykefraversstatistikkVirksomhet> {
         val start = System.currentTimeMillis()
-        val sykefravær = sykefraversstatistikkRepository.hentSykefravær(søkeparametere = søkeparametere)
+        var sykefravær: List<SykefraversstatistikkVirksomhet>
+        if (UnleashKlient.skalHenteSiste4Kvartal()) {
+            TODO()
+        } else {
+            sykefravær = sykefraversstatistikkRepository.hentSykefravær(søkeparametere = søkeparametere)
+        }
 
         log.info("Brukte ${System.currentTimeMillis() - start} ms på å hente statistikk for virksomheter.")
         return sykefravær.map {

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkSiste4KvartalRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkSiste4KvartalRepository.kt
@@ -1,0 +1,246 @@
+package no.nav.lydia.sykefraversstatistikk
+
+import kotlinx.datetime.toKotlinLocalDate
+import kotliquery.Row
+import kotliquery.queryOf
+import kotliquery.sessionOf
+import kotliquery.using
+import no.nav.lydia.UnleashKlient
+import no.nav.lydia.ia.sak.domene.IAProsessStatus
+import no.nav.lydia.sykefraversstatistikk.api.Søkeparametere
+import no.nav.lydia.sykefraversstatistikk.api.geografi.Kommune
+import no.nav.lydia.sykefraversstatistikk.domene.SykefraversstatistikkVirksomhet
+import no.nav.lydia.virksomhet.domene.VirksomhetStatus
+import javax.sql.DataSource
+
+class SykefraværsstatistikkSiste4KvartalRepository(val dataSource: DataSource) {
+    fun hentSykefravær(
+        søkeparametere: Søkeparametere,
+    ) = using(sessionOf(dataSource)) { session ->
+        val skalHentePåSiste4Kvartal = UnleashKlient.skalHenteSiste4Kvartal()
+        val næringsgrupperMedBransjer = søkeparametere.næringsgrupperMedBransjer()
+        val tmpKommuneTabell = "kommuner"
+        val tmpNæringTabell = "naringer"
+        val tmpNavIdenterTabell = "nav_identer"
+        val sql = """
+                    WITH 
+                        ${filterVerdi(tmpKommuneTabell, søkeparametere.kommunenummer)},
+                        ${filterVerdi(tmpNæringTabell, næringsgrupperMedBransjer)},
+                        ${filterVerdi(tmpNavIdenterTabell, søkeparametere.navIdenter)}
+                    SELECT
+                        virksomhet.orgnr,
+                        virksomhet.navn,
+                        virksomhet.kommune,
+                        virksomhet.kommunenummer,
+                        statistikk.arstall,
+                        statistikk.kvartal,
+                        statistikk.antall_personer,
+                        statistikk_siste4.tapte_dagsverk,
+                        statistikk_siste4.mulige_dagsverk,
+                        statistikk_siste4.prosent,
+                        statistikk_siste4.maskert,
+                        statistikk_siste4.sist_endret,
+                        ia_sak.status,
+                        ia_sak.eid_av,
+                        ia_sak.endret
+                    ${
+            filter(
+                tmpKommuneTabell = tmpKommuneTabell,
+                tmpNavIdenterTabell = tmpNavIdenterTabell,
+                tmpNæringTabell = tmpNæringTabell,
+                søkeparametere = søkeparametere
+            )
+        }
+                    GROUP BY 
+                        virksomhet.orgnr,
+                        virksomhet.navn,
+                        virksomhet.kommune,
+                        virksomhet.kommunenummer,
+                        statistikk.arstall,
+                        statistikk.kvartal,
+                        statistikk.antall_personer,
+                        statistikk_siste4.tapte_dagsverk,
+                        statistikk_siste4.mulige_dagsverk,
+                        statistikk_siste4.prosent,
+                        statistikk_siste4.maskert,
+                        statistikk_siste4.sist_endret,
+                        ia_sak.status,
+                        ia_sak.eid_av,
+                        ia_sak.endret
+                    ${søkeparametere.sorteringsnøkkel.tilOrderBy(skalHentePåSiste4Kvartal)} ${søkeparametere.sorteringsretning} NULLS LAST
+                    LIMIT ${søkeparametere.virksomheterPerSide()}
+                    OFFSET ${søkeparametere.offset()}
+                """.trimIndent()
+
+        val query = queryOf(
+            statement = sql, mapOf(
+                tmpKommuneTabell to session.connection.underlying.createArrayOf(
+                    "text", søkeparametere.kommunenummer.toTypedArray()
+                ), tmpNæringTabell to session.connection.underlying.createArrayOf(
+                    "text", næringsgrupperMedBransjer.toTypedArray()
+                ), tmpNavIdenterTabell to session.connection.underlying.createArrayOf(
+                    "text", søkeparametere.navIdenter.toTypedArray()
+                ), "kvartal" to søkeparametere.periode.kvartal, "arstall" to søkeparametere.periode.årstall
+            )
+        ).map(this::mapRow).asList
+        session.run(query)
+    }
+
+    fun hentTotaltAntall(søkeparametere: Søkeparametere): Int? = using(sessionOf(dataSource)) { session ->
+        val næringsgrupperMedBransjer = søkeparametere.næringsgrupperMedBransjer()
+        val tmpKommuneTabell = "kommuner"
+        val tmpNæringTabell = "naringer"
+        val tmpNavIdenterTabell = "nav_identer"
+        val sql = """
+                        WITH 
+                            ${filterVerdi(tmpKommuneTabell, søkeparametere.kommunenummer)},
+                            ${filterVerdi(tmpNæringTabell, næringsgrupperMedBransjer)},
+                            ${filterVerdi(tmpNavIdenterTabell, søkeparametere.navIdenter)}
+                        SELECT
+                            COUNT(DISTINCT virksomhet.orgnr) AS total
+                        ${
+            filter(
+                tmpKommuneTabell = tmpKommuneTabell,
+                tmpNavIdenterTabell = tmpNavIdenterTabell,
+                tmpNæringTabell = tmpNæringTabell,
+                søkeparametere = søkeparametere
+            )
+        }
+                    """.trimIndent()
+
+        val query = queryOf(
+            statement = sql, mapOf(
+                tmpKommuneTabell to session.connection.underlying.createArrayOf(
+                    "text", søkeparametere.kommunenummer.toTypedArray()
+                ), tmpNæringTabell to session.connection.underlying.createArrayOf(
+                    "text", næringsgrupperMedBransjer.toTypedArray()
+                ), tmpNavIdenterTabell to session.connection.underlying.createArrayOf(
+                    "text", søkeparametere.navIdenter.toTypedArray()
+                ), "kvartal" to søkeparametere.periode.kvartal, "arstall" to søkeparametere.periode.årstall
+            )
+        )
+        session.run(query.map { it.int("total") }.asSingle)
+    }
+
+    private fun filter(
+        tmpKommuneTabell: String,
+        tmpNavIdenterTabell: String,
+        tmpNæringTabell: String,
+        søkeparametere: Søkeparametere,
+    ) = """
+        FROM sykefravar_statistikk_virksomhet AS statistikk
+        JOIN virksomhet USING (orgnr)
+        LEFT JOIN sykefravar_statistikk_virksomhet_siste_4_kvartal AS statistikk_siste4 USING (orgnr)
+        LEFT JOIN ia_sak ON (
+            (ia_sak.orgnr = statistikk.orgnr) AND
+            ia_sak.endret = (select max(endret) from ia_sak iasak2 where iasak2.orgnr = statistikk.orgnr)
+        )
+        JOIN virksomhet_naring AS vn on (virksomhet.id = vn.virksomhet)
+        
+        WHERE (
+            (SELECT inkluderAlle FROM $tmpKommuneTabell) IS TRUE OR
+            virksomhet.kommunenummer in (select unnest($tmpKommuneTabell.filterverdi) FROM $tmpKommuneTabell)
+        )
+        AND (
+            (SELECT inkluderAlle FROM $tmpNavIdenterTabell) IS TRUE OR
+            ia_sak.eid_av in (select unnest($tmpNavIdenterTabell.filterverdi) FROM $tmpNavIdenterTabell)
+        )
+        AND (
+            (SELECT inkluderAlle FROM $tmpNæringTabell) IS TRUE
+            OR substr(vn.narings_kode, 1, 2) in (select unnest($tmpNæringTabell.filterverdi) FROM $tmpNæringTabell)
+            ${
+        if (søkeparametere.bransjeprogram.isNotEmpty()) {
+            val koder = søkeparametere.bransjeprogram.flatMap { it.næringskoder }.groupBy {
+                it.length
+            }
+            val femsifrede = koder[5]?.joinToString { "'${it.take(2)}.${it.takeLast(3)}'" }
+            femsifrede?.let { "OR (vn.narings_kode in (select unnest($tmpNæringTabell.filterverdi) FROM $tmpNæringTabell))" } ?: ""
+        } else ""
+    }
+        )
+        AND statistikk.kvartal = :kvartal
+        AND statistikk.arstall = :arstall
+                        
+        ${
+        søkeparametere.status?.let { status ->
+            when (status) {
+                IAProsessStatus.IKKE_AKTIV -> " AND ia_sak.status IS NULL"
+                else -> " AND ia_sak.status = '$status'"
+            }
+        } ?: ""
+    }
+                        
+        ${søkeparametere.sykefraværsprosentFra?.let { " AND statistikk_siste4.prosent >= $it " } ?: ""}
+        ${søkeparametere.sykefraværsprosentTil?.let { " AND statistikk_siste4.prosent <= $it " } ?: ""}
+        
+        ${søkeparametere.ansatteFra?.let { " AND statistikk.antall_personer >= $it " } ?: ""}
+        ${søkeparametere.ansatteTil?.let { " AND statistikk.antall_personer <= $it " } ?: ""}
+        AND virksomhet.status = '${VirksomhetStatus.AKTIV.name}'
+        """.trimIndent()
+
+
+    fun hentSykefraværForVirksomhet(orgnr: String): List<SykefraversstatistikkVirksomhet> {
+        return using(sessionOf(dataSource)) { session ->
+            val query = queryOf(
+                statement = """
+                    SELECT
+                        statistikk_siste4.orgnr,
+                        virksomhet.navn,
+                        virksomhet.kommune,
+                        virksomhet.kommunenummer,
+                        statistikk.arstall,
+                        statistikk.kvartal,
+                        statistikk.antall_personer,
+                        statistikk_siste4.tapte_dagsverk,
+                        statistikk_siste4.mulige_dagsverk,
+                        statistikk_siste4.prosent,
+                        statistikk_siste4.maskert,
+                        statistikk_siste4.sist_endret,
+                        ia_sak.status,
+                        ia_sak.eid_av,
+                        ia_sak.endret
+                  FROM sykefravar_statistikk_virksomhet AS statistikk
+                  JOIN virksomhet USING (orgnr)
+                  LEFT JOIN sykefravar_statistikk_virksomhet_siste_4_kvartal AS statistikk_siste4 USING (orgnr)
+                  LEFT JOIN ia_sak USING(orgnr)
+                  WHERE (statistikk.orgnr = :orgnr)
+                """.trimIndent(), paramMap = mapOf(
+                    "orgnr" to orgnr
+                )
+            ).map(this::mapRow).asList
+            session.run(query)
+        }
+    }
+
+    private fun filterVerdi(filterNavn: String, filterVerdier: Set<String>) = """
+            $filterNavn (inkluderAlle, filterverdi) AS (
+                    VALUES (
+                        ${filterVerdier.isEmpty()},
+                        :$filterNavn
+                    )    
+                )
+        """.trimIndent()
+
+    private fun mapRow(row: Row): SykefraversstatistikkVirksomhet {
+        return SykefraversstatistikkVirksomhet(
+            virksomhetsnavn = row.string("navn"),
+            kommune = Kommune(row.string("kommune"), row.string("kommunenummer")),
+            orgnr = row.string("orgnr"),
+            arstall = row.int("arstall"),
+            kvartal = row.int("kvartal"),
+            antallPersoner = row.double("antall_personer"),
+            tapteDagsverk = row.double("tapte_dagsverk"),
+            muligeDagsverk = row.double("mulige_dagsverk"),
+            sykefraversprosent = if (UnleashKlient.skalHenteSiste4Kvartal()) row.double("prosent") else row.double("sykefraversprosent"),
+            maskert = row.boolean("maskert"),
+            opprettet = if (UnleashKlient.skalHenteSiste4Kvartal()) row.localDateTime("sist_endret") else row.localDateTime(
+                "opprettet"
+            ),
+            status = row.stringOrNull("status")?.let {
+                IAProsessStatus.valueOf(it)
+            },
+            eidAv = row.stringOrNull("eid_av"),
+            sistEndret = row.localDateOrNull("endret")?.toKotlinLocalDate()
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkSiste4KvartalRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkSiste4KvartalRepository.kt
@@ -17,7 +17,6 @@ class SykefraværsstatistikkSiste4KvartalRepository(val dataSource: DataSource) 
     fun hentSykefravær(
         søkeparametere: Søkeparametere,
     ) = using(sessionOf(dataSource)) { session ->
-        val skalHentePåSiste4Kvartal = UnleashKlient.skalHenteSiste4Kvartal()
         val næringsgrupperMedBransjer = søkeparametere.næringsgrupperMedBransjer()
         val tmpKommuneTabell = "kommuner"
         val tmpNæringTabell = "naringer"
@@ -67,7 +66,7 @@ class SykefraværsstatistikkSiste4KvartalRepository(val dataSource: DataSource) 
                         ia_sak.status,
                         ia_sak.eid_av,
                         ia_sak.endret
-                    ${søkeparametere.sorteringsnøkkel.tilOrderBy(skalHentePåSiste4Kvartal)} ${søkeparametere.sorteringsretning} NULLS LAST
+                    ${søkeparametere.sorteringsnøkkel.tilOrderBy(true)} ${søkeparametere.sorteringsretning} NULLS LAST
                     LIMIT ${søkeparametere.virksomheterPerSide()}
                     OFFSET ${søkeparametere.offset()}
                 """.trimIndent()
@@ -231,11 +230,9 @@ class SykefraværsstatistikkSiste4KvartalRepository(val dataSource: DataSource) 
             antallPersoner = row.double("antall_personer"),
             tapteDagsverk = row.double("tapte_dagsverk"),
             muligeDagsverk = row.double("mulige_dagsverk"),
-            sykefraversprosent = if (UnleashKlient.skalHenteSiste4Kvartal()) row.double("prosent") else row.double("sykefraversprosent"),
+            sykefraversprosent = row.double("prosent"),
             maskert = row.boolean("maskert"),
-            opprettet = if (UnleashKlient.skalHenteSiste4Kvartal()) row.localDateTime("sist_endret") else row.localDateTime(
-                "opprettet"
-            ),
+            opprettet = row.localDateTime("sist_endret"),
             status = row.stringOrNull("status")?.let {
                 IAProsessStatus.valueOf(it)
             },

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkSiste4KvartalRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkSiste4KvartalRepository.kt
@@ -5,8 +5,9 @@ import kotliquery.Row
 import kotliquery.queryOf
 import kotliquery.sessionOf
 import kotliquery.using
-import no.nav.lydia.UnleashKlient
 import no.nav.lydia.ia.sak.domene.IAProsessStatus
+import no.nav.lydia.sykefraversstatistikk.api.Sorteringsnøkkel
+import no.nav.lydia.sykefraversstatistikk.api.Sorteringsnøkkel.*
 import no.nav.lydia.sykefraversstatistikk.api.Søkeparametere
 import no.nav.lydia.sykefraversstatistikk.api.geografi.Kommune
 import no.nav.lydia.sykefraversstatistikk.domene.SykefraversstatistikkVirksomhet
@@ -66,7 +67,7 @@ class SykefraværsstatistikkSiste4KvartalRepository(val dataSource: DataSource) 
                         ia_sak.status,
                         ia_sak.eid_av,
                         ia_sak.endret
-                    ${søkeparametere.sorteringsnøkkel.tilOrderBy(true)} ${søkeparametere.sorteringsretning} NULLS LAST
+                    ${søkeparametere.sorteringsnøkkel.tilOrderBy()} ${søkeparametere.sorteringsretning} NULLS LAST
                     LIMIT ${søkeparametere.virksomheterPerSide()}
                     OFFSET ${søkeparametere.offset()}
                 """.trimIndent()
@@ -83,6 +84,16 @@ class SykefraværsstatistikkSiste4KvartalRepository(val dataSource: DataSource) 
             )
         ).map(this::mapRow).asList
         session.run(query)
+    }
+
+    private fun Sorteringsnøkkel.tilOrderBy(): String {
+        return when(this) {
+            NAVN_PÅ_VIRKSOMHET -> "ORDER BY virksomhet.navn"
+            ANTALL_PERSONER -> "ORDER BY statistikk.antall_personer"
+            SYKEFRAVÆRSPROSENT -> "ORDER BY statistikk_siste4.prosent"
+            TAPTE_DAGSVERK -> "ORDER BY statistikk_siste4.tapte_dagsverk"
+            MULIGE_DAGSVERK -> "ORDER BY statistikk_siste4.mulige_dagsverk"
+        }
     }
 
     fun hentTotaltAntall(søkeparametere: Søkeparametere): Int? = using(sessionOf(dataSource)) { session ->

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/api/Søkeparametere.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/api/Søkeparametere.kt
@@ -69,7 +69,8 @@ data class Søkeparametere(
                 when (rådgiver.rolle) {
                     SUPERBRUKER -> eiere.toSet()
                     SAKSBEHANDLER,
-                    LESE -> eiere.filter { it == rådgiver.navIdent }.toSet()
+                    LESE,
+                    -> eiere.filter { it == rådgiver.navIdent }.toSet()
                 }
             }
         }
@@ -140,14 +141,26 @@ enum class Sorteringsnøkkel(private val verdi: String, private val tabell: Stri
     TAPTE_DAGSVERK("tapte_dagsverk", SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN),
     ANTALL_PERSONER("antall_personer", SYKEFRAVÆR_TABELLNAVN),
     MULIGE_DAGSVERK("mulige_dagsverk", SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN),
-    SYKEFRAVÆRSPROSENT("sykefraversprosent", SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN);
+    SYKEFRAVÆRSPROSENT("prosent", SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN);
 
     companion object {
         fun from(verdi: String?) = values().find { it.verdi == verdi?.lowercase() } ?: TAPTE_DAGSVERK
         fun alleSorteringsNøkler() = values().map { it.toString() }
     }
 
-    fun tilOrderBy() = "ORDER BY ${tabell}.${verdi}"
+    fun tilOrderBy(brukStatistikkSiste4Kvartal: Boolean): String {
+        var oppdatertTabell = tabell
+        var oppdatertVerdi = verdi
+
+        if (!brukStatistikkSiste4Kvartal && tabell == SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN) {
+            oppdatertTabell = SYKEFRAVÆR_TABELLNAVN
+            if (verdi == "prosent") {
+                oppdatertVerdi = "sykefraversprosent"
+            }
+        }
+
+        return "ORDER BY ${oppdatertTabell}.${oppdatertVerdi}"
+    }
 
     override fun toString(): String = this.verdi
 

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/api/Søkeparametere.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/api/Søkeparametere.kt
@@ -132,14 +132,15 @@ class Periode(val kvartal: Int, val årstall: Int) {
 }
 
 private const val SYKEFRAVÆR_TABELLNAVN = "statistikk"
+private const val SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN = "statistikk_siste4"
 private const val VIRKSOMHET_TABELLNAVN = "virksomhet"
 
 enum class Sorteringsnøkkel(private val verdi: String, private val tabell: String) {
     NAVN_PÅ_VIRKSOMHET("navn", VIRKSOMHET_TABELLNAVN),
-    TAPTE_DAGSVERK("tapte_dagsverk", SYKEFRAVÆR_TABELLNAVN),
+    TAPTE_DAGSVERK("tapte_dagsverk", SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN),
     ANTALL_PERSONER("antall_personer", SYKEFRAVÆR_TABELLNAVN),
-    MULIGE_DAGSVERK("mulige_dagsverk", SYKEFRAVÆR_TABELLNAVN),
-    SYKEFRAVÆRSPROSENT("sykefraversprosent", SYKEFRAVÆR_TABELLNAVN);
+    MULIGE_DAGSVERK("mulige_dagsverk", SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN),
+    SYKEFRAVÆRSPROSENT("sykefraversprosent", SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN);
 
     companion object {
         fun from(verdi: String?) = values().find { it.verdi == verdi?.lowercase() } ?: TAPTE_DAGSVERK

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/api/Søkeparametere.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/api/Søkeparametere.kt
@@ -132,38 +132,19 @@ class Periode(val kvartal: Int, val årstall: Int) {
     }
 }
 
-private const val SYKEFRAVÆR_TABELLNAVN = "statistikk"
-private const val SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN = "statistikk_siste4"
-private const val VIRKSOMHET_TABELLNAVN = "virksomhet"
-
-enum class Sorteringsnøkkel(private val verdi: String, private val tabell: String) {
-    NAVN_PÅ_VIRKSOMHET("navn", VIRKSOMHET_TABELLNAVN),
-    TAPTE_DAGSVERK("tapte_dagsverk", SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN),
-    ANTALL_PERSONER("antall_personer", SYKEFRAVÆR_TABELLNAVN),
-    MULIGE_DAGSVERK("mulige_dagsverk", SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN),
-    SYKEFRAVÆRSPROSENT("prosent", SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN);
+enum class Sorteringsnøkkel(val verdi: String) {
+    NAVN_PÅ_VIRKSOMHET("navn"),
+    TAPTE_DAGSVERK("tapte_dagsverk"),
+    ANTALL_PERSONER("antall_personer"),
+    MULIGE_DAGSVERK("mulige_dagsverk"),
+    SYKEFRAVÆRSPROSENT("sykefraversprosent");
 
     companion object {
         fun from(verdi: String?) = values().find { it.verdi == verdi?.lowercase() } ?: TAPTE_DAGSVERK
         fun alleSorteringsNøkler() = values().map { it.toString() }
     }
 
-    fun tilOrderBy(brukStatistikkSiste4Kvartal: Boolean): String {
-        var oppdatertTabell = tabell
-        var oppdatertVerdi = verdi
-
-        if (!brukStatistikkSiste4Kvartal && tabell == SYKEFRAVÆR_SISTE_4_KVARTALER_TABELLNAVN) {
-            oppdatertTabell = SYKEFRAVÆR_TABELLNAVN
-            if (verdi == "prosent") {
-                oppdatertVerdi = "sykefraversprosent"
-            }
-        }
-
-        return "ORDER BY ${oppdatertTabell}.${oppdatertVerdi}"
-    }
-
     override fun toString(): String = this.verdi
-
 }
 
 

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkPerKategoriImportDto.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkPerKategoriImportDto.kt
@@ -53,3 +53,10 @@ data class SistePubliserteKvartal(
     @SerializedName("erMaskert")
     val erMaskert: Boolean
 )
+
+data class KeySykefraversstatistikkPerKategori(
+    val kategori: String,
+    val kode: String,
+    val kvartal: Int,
+    val årstall: Int,
+)

--- a/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkApiTest.kt
@@ -130,7 +130,7 @@ class SykefraversstatistikkApiTest {
 
     @Test
     fun `skal kunne hente sykefraværsstatistikk med feature henteSiste4Kvartal enablet`() {
-        val sorteringsnøkkel = "prosent"
+        val sorteringsnøkkel = Sorteringsnøkkel.SYKEFRAVÆRSPROSENT.verdi
 
         medFeatureToggleEnablet(UnleashToggleKeys.henteSiste4Kvartal) {
             hentSykefravær(

--- a/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkApiTest.kt
@@ -5,13 +5,7 @@ import ia.felles.definisjoner.bransjer.Bransjer
 import io.kotest.inspectors.forAll
 import io.kotest.inspectors.forAtLeastOne
 import io.kotest.matchers.booleans.shouldBeTrue
-import io.kotest.matchers.collections.shouldBeIn
-import io.kotest.matchers.collections.shouldBeOneOf
-import io.kotest.matchers.collections.shouldContainAll
-import io.kotest.matchers.collections.shouldContainInOrder
-import io.kotest.matchers.collections.shouldHaveAtLeastSize
-import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.collections.shouldNotContainAnyOf
+import io.kotest.matchers.collections.*
 import io.kotest.matchers.doubles.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.doubles.shouldBeLessThanOrEqual
 import io.kotest.matchers.ints.shouldBeGreaterThan
@@ -63,11 +57,7 @@ import no.nav.lydia.ia.sak.api.IA_SAK_RADGIVER_PATH
 import no.nav.lydia.ia.sak.domene.ANTALL_DAGER_FØR_SAK_LÅSES
 import no.nav.lydia.ia.sak.domene.IAProsessStatus
 import no.nav.lydia.ia.sak.domene.IASakshendelseType.TA_EIERSKAP_I_SAK
-import no.nav.lydia.sykefraversstatistikk.api.EierDTO
-import no.nav.lydia.sykefraversstatistikk.api.FILTERVERDIER_PATH
-import no.nav.lydia.sykefraversstatistikk.api.Periode
-import no.nav.lydia.sykefraversstatistikk.api.SYKEFRAVERSSTATISTIKK_PATH
-import no.nav.lydia.sykefraversstatistikk.api.SykefraværsstatistikkListResponseDto
+import no.nav.lydia.sykefraversstatistikk.api.*
 import no.nav.lydia.sykefraversstatistikk.api.Søkeparametere.Companion.VIRKSOMHETER_PER_SIDE
 import no.nav.lydia.sykefraversstatistikk.api.geografi.GeografiService
 import no.nav.lydia.sykefraversstatistikk.api.geografi.Kommune
@@ -129,6 +119,17 @@ class SykefraversstatistikkApiTest {
                 sorteringsretning = "desc",
                 token = mockOAuth2Server.saksbehandler1.token
             )
+        }
+    }
+
+    @Test
+    fun `skal kunne hente sykefraværsstatistikk for en virksomhet med feature henteSiste4Kvartal enablet`() {
+        val orgnummer = nyttOrgnummer()
+
+        medFeatureToggleEnablet(UnleashToggleKeys.henteSiste4Kvartal) {
+            hentSykefraværForVirksomhet(orgnummer = orgnummer).forAtLeastOne {
+                it.sykefraversprosent shouldBeGreaterThanOrEqual 10.0
+            }
         }
     }
 

--- a/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkApiTest.kt
@@ -2,7 +2,6 @@ package no.nav.lydia.container.sykefraversstatistikk
 
 import com.github.kittinunf.fuel.core.extensions.authentication
 import ia.felles.definisjoner.bransjer.Bransjer
-import io.kotest.assertions.shouldFail
 import io.kotest.inspectors.forAll
 import io.kotest.inspectors.forAtLeastOne
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -114,21 +113,22 @@ class SykefraversstatistikkApiTest {
 
 
     @Test
-    fun `skal ikke kunne hente sykefraværsstatistikk med feature henteSiste4Kvartal enablet`() {
+    fun `skal kunne hente sykefraværsstatistikk med feature henteSiste4Kvartal enablet`() {
         val sorteringsnøkkel = "tapte_dagsverk"
 
         medFeatureToggleEnablet(UnleashToggleKeys.henteSiste4Kvartal) {
-            shouldFail {
-                hentSykefravær(
-                    success = { response ->
-                        val tapteDagsverk = response.data.map { it.tapteDagsverk }
-                        tapteDagsverk shouldContainInOrder tapteDagsverk.sortedDescending()
-                    },
-                    sorteringsnokkel = sorteringsnøkkel,
-                    sorteringsretning = "desc",
-                    token = mockOAuth2Server.saksbehandler1.token
-                )
-            }
+            hentSykefravær(
+                success = { response ->
+                    val tapteDagsverk = response.data.map { it.tapteDagsverk }
+                    tapteDagsverk shouldContainInOrder tapteDagsverk.sortedDescending()
+                    response.data.forAll {
+                        it.sykefraversprosent shouldBeGreaterThanOrEqual 10.0
+                    }
+                },
+                sorteringsnokkel = sorteringsnøkkel,
+                sorteringsretning = "desc",
+                token = mockOAuth2Server.saksbehandler1.token
+            )
         }
     }
 

--- a/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkApiTest.kt
@@ -2,6 +2,7 @@ package no.nav.lydia.container.sykefraversstatistikk
 
 import com.github.kittinunf.fuel.core.extensions.authentication
 import ia.felles.definisjoner.bransjer.Bransjer
+import io.kotest.assertions.shouldFail
 import io.kotest.inspectors.forAll
 import io.kotest.inspectors.forAtLeastOne
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -113,24 +114,21 @@ class SykefraversstatistikkApiTest {
 
 
     @Test
-    fun `skal kunne sortere sykefraværsstatistikk på valgfri nøkkel når statistikk siste 4 kvartaler er aktivert`() {
+    fun `skal ikke kunne hente sykefraværsstatistikk med feature henteSiste4Kvartal enablet`() {
         val sorteringsnøkkel = "tapte_dagsverk"
 
         medFeatureToggleEnablet(UnleashToggleKeys.henteSiste4Kvartal) {
-            hentSykefravær(
-                success = { response ->
-                    val tapteDagsverk = response.data.map { it.tapteDagsverk }
-                    tapteDagsverk shouldContainInOrder tapteDagsverk.sortedDescending()
-                },
-                sorteringsnokkel = sorteringsnøkkel,
-                sorteringsretning = "desc",
-                token = mockOAuth2Server.saksbehandler1.token
-            )
-
-            hentSykefravær(success = { response ->
-                val tapteDagsverk = response.data.map { it.tapteDagsverk }
-                tapteDagsverk shouldContainInOrder tapteDagsverk.sorted()
-            }, sorteringsnokkel = sorteringsnøkkel, sorteringsretning = "asc")
+            shouldFail {
+                hentSykefravær(
+                    success = { response ->
+                        val tapteDagsverk = response.data.map { it.tapteDagsverk }
+                        tapteDagsverk shouldContainInOrder tapteDagsverk.sortedDescending()
+                    },
+                    sorteringsnokkel = sorteringsnøkkel,
+                    sorteringsretning = "desc",
+                    token = mockOAuth2Server.saksbehandler1.token
+                )
+            }
         }
     }
 

--- a/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkImportTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkImportTest.kt
@@ -43,7 +43,7 @@ class SykefraversstatistikkImportTest {
         kafkaContainer.sendSykefraversstatistikkKafkaMelding(
             importDto = SykefraværsstatistikkTestData.testVirksomhetForrigeKvartal.sykefraværsstatistikkImportDto
         )
-        kafkaContainer.sendSykefraversstatostikkPerKategoriKafkaMelding(
+        kafkaContainer.sendSykefraversstatistikkPerKategoriKafkaMelding(
             importDto = SykefraværsstatistikkPerKategoriTestData.testVirksomhetForrigeKvartal.sykefraversstatistikkPerKategoriImportDto
         )
 
@@ -57,7 +57,7 @@ class SykefraversstatistikkImportTest {
         kafkaContainer.sendSykefraversstatistikkKafkaMelding(
             importDto = SykefraværsstatistikkTestData.testVirksomhetGjeldeneKvartal.sykefraværsstatistikkImportDto
         )
-        kafkaContainer.sendSykefraversstatostikkPerKategoriKafkaMelding(
+        kafkaContainer.sendSykefraversstatistikkPerKategoriKafkaMelding(
             importDto = SykefraværsstatistikkPerKategoriTestData.testVirksomhetGjeldeneKvartal.sykefraversstatistikkPerKategoriImportDto
         )
 
@@ -79,7 +79,7 @@ class SykefraversstatistikkImportTest {
         val sykefraværsstatistikk = SykefraværsstatistikkTestData.testVirksomhetForrigeKvartal.sykefraværsstatistikkImportDto
         val sykefraværsstatistikkPerKategori = SykefraværsstatistikkPerKategoriTestData.testVirksomhetForrigeKvartal.sykefraversstatistikkPerKategoriImportDto
         kafkaContainer.sendSykefraversstatistikkKafkaMelding(sykefraværsstatistikk)
-        kafkaContainer.sendSykefraversstatostikkPerKategoriKafkaMelding(sykefraværsstatistikkPerKategori)
+        kafkaContainer.sendSykefraversstatistikkPerKategoriKafkaMelding(sykefraværsstatistikkPerKategori)
 
         val dtos = hentSykefraværsstatistikk(TESTVIRKSOMHET_FOR_IMPORT.orgnr)
         dtos.size shouldBeGreaterThanOrEqual 1
@@ -97,10 +97,10 @@ class SykefraversstatistikkImportTest {
     @Test
     fun `import av data er idempotent`() {
         kafkaContainer.sendSykefraversstatistikkKafkaMelding(SykefraværsstatistikkTestData.testVirksomhetForrigeKvartal.sykefraværsstatistikkImportDto)
-        kafkaContainer.sendSykefraversstatostikkPerKategoriKafkaMelding(SykefraværsstatistikkPerKategoriTestData.testVirksomhetForrigeKvartal.sykefraversstatistikkPerKategoriImportDto)
+        kafkaContainer.sendSykefraversstatistikkPerKategoriKafkaMelding(SykefraværsstatistikkPerKategoriTestData.testVirksomhetForrigeKvartal.sykefraversstatistikkPerKategoriImportDto)
         val førsteLagredeStatistikk = hentSykefraværsstatistikk(TESTVIRKSOMHET_FOR_IMPORT.orgnr)
         kafkaContainer.sendSykefraversstatistikkKafkaMelding(SykefraværsstatistikkTestData.testVirksomhetForrigeKvartal.sykefraværsstatistikkImportDto)
-        kafkaContainer.sendSykefraversstatostikkPerKategoriKafkaMelding(SykefraværsstatistikkPerKategoriTestData.testVirksomhetForrigeKvartal.sykefraversstatistikkPerKategoriImportDto)
+        kafkaContainer.sendSykefraversstatistikkPerKategoriKafkaMelding(SykefraværsstatistikkPerKategoriTestData.testVirksomhetForrigeKvartal.sykefraversstatistikkPerKategoriImportDto)
         val andreLagredeStatistikk = hentSykefraværsstatistikk(TESTVIRKSOMHET_FOR_IMPORT.orgnr)
         andreLagredeStatistikk.forExactlyOne { dto ->
             dto.orgnr shouldBe førsteLagredeStatistikk[0].orgnr
@@ -158,7 +158,7 @@ class SykefraversstatistikkImportTest {
             tapteDagsverk = 16.0,
         )
         kafkaContainer.sendSykefraversstatistikkKafkaMelding(opppdatertStatistikk)
-        kafkaContainer.sendSykefraversstatostikkPerKategoriKafkaMelding(opppdatertStatistikk4SisteKvartal)
+        kafkaContainer.sendSykefraversstatistikkPerKategoriKafkaMelding(opppdatertStatistikk4SisteKvartal)
         hentSykefraværsstatistikk(virksomhet.orgnr).forExactlyOne {
             it.sykefraversprosent shouldBe 3.0
             it.antallPersoner shouldBe 1337

--- a/src/test/kotlin/no/nav/lydia/helper/KafkaContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/KafkaContainerHelper.kt
@@ -153,7 +153,7 @@ class KafkaContainerHelper(
         }
     }
 
-    fun sendSykefraversstatostikkPerKategoriIBulkOgVentTilKonsumert(
+    fun sendSykefraversstatistikkPerKategoriIBulkOgVentTilKonsumert(
         importDtoer: List<SykefraversstatistikkPerKategoriImportDto>,
     ) {
         runBlocking {
@@ -171,7 +171,7 @@ class KafkaContainerHelper(
         }
     }
 
-    fun sendSykefraversstatostikkPerKategoriKafkaMelding(importDto: SykefraversstatistikkPerKategoriImportDto) {
+    fun sendSykefraversstatistikkPerKategoriKafkaMelding(importDto: SykefraversstatistikkPerKategoriImportDto) {
         runBlocking {
             val sendtMelding = kafkaProducer.send(importDto.tilProducerRecord()).get()
             ventTilKonsumert(sendtMelding.offset())

--- a/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
@@ -542,6 +542,10 @@ class VirksomhetHelper {
             TestContainerHelper.kafkaContainerHelper.sendIBulkOgVentTilKonsumert(
                 testData.sykefraværsStatistikkMeldinger().toList()
             )
+
+            TestContainerHelper.kafkaContainerHelper.sendSykefraversstatostikkPerKategoriIBulkOgVentTilKonsumert(
+                testData.sykefraværsstatistikkPerKategoriMeldinger().toList()
+            )
         }
     }
 }

--- a/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
@@ -543,7 +543,7 @@ class VirksomhetHelper {
                 testData.sykefraværsStatistikkMeldinger().toList()
             )
 
-            TestContainerHelper.kafkaContainerHelper.sendSykefraversstatostikkPerKategoriIBulkOgVentTilKonsumert(
+            TestContainerHelper.kafkaContainerHelper.sendSykefraversstatistikkPerKategoriIBulkOgVentTilKonsumert(
                 testData.sykefraværsstatistikkPerKategoriMeldinger().toList()
             )
         }

--- a/src/test/kotlin/no/nav/lydia/helper/TestData.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestData.kt
@@ -123,7 +123,7 @@ class TestData(
                     kategori = Kategori.VIRKSOMHET,
                     kode = virksomhet.orgnr,
                     periode = periode,
-                    sykefraværsProsent = sykefraværsProsent,
+                    sykefraværsProsent = sykefraværsProsent + 10.0,
                     antallPersoner = antallPersoner.toInt(),
                     tapteDagsverk = tapteDagsverk,
                 )

--- a/src/test/kotlin/no/nav/lydia/helper/TestData.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestData.kt
@@ -9,6 +9,9 @@ import no.nav.lydia.sykefraversstatistikk.import.*
 import no.nav.lydia.virksomhet.domene.Næringsgruppe
 import kotlin.random.Random
 
+const val MIN_PROSENT_FOR_SISTE_4_KVARTAL = 50.0
+const val MAX_PROSENT_FOR_SISTE_KVARTAL = 20
+
 class TestData(
     inkluderStandardVirksomheter: Boolean = false,
     antallTilfeldigeVirksomheter: Int = 0,
@@ -34,7 +37,7 @@ class TestData(
             TestData().lagData(
                 virksomhet = virksomhet,
                 perioder = listOf(Periode.gjeldendePeriode()),
-                sykefraværsProsent = (1..20).random().toDouble()
+                sykefraværsProsent = (1..MAX_PROSENT_FOR_SISTE_KVARTAL).random().toDouble()
             )
 
     }
@@ -123,7 +126,7 @@ class TestData(
                     kategori = Kategori.VIRKSOMHET,
                     kode = virksomhet.orgnr,
                     periode = periode,
-                    sykefraværsProsent = sykefraværsProsent + 10.0,
+                    sykefraværsProsent = sykefraværsProsent + MIN_PROSENT_FOR_SISTE_4_KVARTAL,
                     antallPersoner = antallPersoner.toInt(),
                     tapteDagsverk = tapteDagsverk,
                 )

--- a/src/test/kotlin/no/nav/lydia/helper/TestData.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestData.kt
@@ -105,7 +105,7 @@ class TestData(
     fun lagData(
         virksomhet: TestVirksomhet,
         perioder: List<Periode>,
-        sykefraværsProsent: Double = 2.0,
+        sykefraværsProsent: Double = (1..MAX_PROSENT_FOR_SISTE_KVARTAL).random().toDouble(),
         antallPersoner: Double = Random.nextDouble(5.0, 1000.0),
         tapteDagsverk: Double = Random.nextDouble(5.0, 10000.0),
         sektor: String = SEKTOR_STATLIG_FORVALTNING,


### PR DESCRIPTION
Denne PR inneholder følgende endringer: 

- uthenting av sykefraværsstatistikk (prosent, mulige dagsverk og tapte dagsverk) over siste 4 kvartal
- feature toggle `pia.hente-siste-4-kvartaler` som enabler uthenting av sykefraværsstatistikk over siste 4 kvartal (siste gjeldende kvartal når toggle er av)
