### PR TITLE
Graceful shutdown consumer

### DIFF
--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/BrregOppdateringConsumer.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/BrregOppdateringConsumer.kt
@@ -96,7 +96,7 @@ object BrregOppdateringConsumer : CoroutineScope {
                         delay(kafka.consumerLoopDelay)
                     }
                 } catch (e: WakeupException) {
-                    logger.info("Consumer is shutting down...")
+                    logger.info("BrregOppdateringConsumer is shutting down...")
                 }
                 catch (e: Exception) {
                     logger.error("Exception is shutting down kafka listner for ${kafka.brregOppdateringTopic}", e)

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/BrregOppdateringConsumer.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/BrregOppdateringConsumer.kt
@@ -50,9 +50,9 @@ object BrregOppdateringConsumer : CoroutineScope {
     fun run() {
         launch {
             kafkaConsumer.use { consumer ->
-                consumer.subscribe(listOf(kafka.brregOppdateringTopic))
-                logger.info("Kafka consumer subscribed to ${kafka.brregOppdateringTopic}")
                 try {
+                    consumer.subscribe(listOf(kafka.brregOppdateringTopic))
+                    logger.info("Kafka consumer subscribed to ${kafka.brregOppdateringTopic}")
                     while (job.isActive) {
                         try {
                             val records = consumer.poll(Duration.ofSeconds(1))
@@ -97,8 +97,7 @@ object BrregOppdateringConsumer : CoroutineScope {
                     }
                 } catch (e: WakeupException) {
                     logger.info("BrregOppdateringConsumer is shutting down...")
-                }
-                catch (e: Exception) {
+                } catch (e: Exception) {
                     logger.error("Exception is shutting down kafka listner for ${kafka.brregOppdateringTopic}", e)
                     throw e
                 }

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkConsumer.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkConsumer.kt
@@ -65,15 +65,16 @@ object StatistikkConsumer : CoroutineScope, Helsesjekk {
                             logger.info("Lagret ${records.count()} ${kafka.statistikkTopic} meldinger")
 
                             consumer.commitSync()
-                            delay(kafka.consumerLoopDelay)
                         } catch (e: RetriableException) {
                             logger.warn("Had a retriable exception for ${kafka.statistikkTopic} topic, retrying", e)
                         }
+                        delay(kafka.consumerLoopDelay)
                     }
                 } catch (e: WakeupException) {
                     logger.info("Consumer is shutting down...")
                 } catch (e: Exception) {
                     logger.error("Exception is shutting down kafka listner for ${kafka.statistikkTopic}", e)
+                    throw e
                 }
             }
         }

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkConsumer.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkConsumer.kt
@@ -1,12 +1,7 @@
 package no.nav.lydia.sykefraversstatistikk.import
 
 import com.google.gson.GsonBuilder
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import no.nav.lydia.Kafka
 import no.nav.lydia.appstatus.Helse
 import no.nav.lydia.appstatus.Helsesjekk
@@ -16,6 +11,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.errors.RetriableException
+import org.apache.kafka.common.errors.WakeupException
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -26,6 +22,7 @@ object StatistikkConsumer : CoroutineScope, Helsesjekk {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
     lateinit var job: Job
     lateinit var kafka: Kafka
+    private lateinit var kafkaConsumer: KafkaConsumer<String, String>
 
     lateinit var sykefraværsstatistikkService: SykefraværsstatistikkService
 
@@ -42,42 +39,42 @@ object StatistikkConsumer : CoroutineScope, Helsesjekk {
         this.job = Job()
         this.kafka = kafka
         this.sykefraværsstatistikkService = sykefraværsstatistikkService
+        this.kafkaConsumer = KafkaConsumer(
+            StatistikkConsumer.kafka.consumerProperties(),
+            StringDeserializer(),
+            StringDeserializer()
+        )
         logger.info("Created kafka consumer job for ${kafka.statistikkTopic}")
     }
 
     fun run() {
         launch {
-            KafkaConsumer(
-                kafka.consumerProperties(),
-                StringDeserializer(),
-                StringDeserializer()
-            ).use { consumer ->
-                consumer.subscribe(listOf(kafka.statistikkTopic))
-                logger.info("Kafka consumer subscribed to ${kafka.statistikkTopic}")
+            kafkaConsumer.use { consumer ->
+                try {
+                    consumer.subscribe(listOf(kafka.statistikkTopic))
+                    logger.info("Kafka consumer subscribed to ${kafka.statistikkTopic}")
+                    while (job.isActive) {
+                        try {
+                            val records = consumer.poll(Duration.ofSeconds(1))
+                            if (records.count() < 1) continue
+                            logger.info("Fant ${records.count()} nye ${kafka.statistikkTopic} meldinger")
+                            sykefraværsstatistikkService.lagre(
+                                sykefraværsstatistikkListe =
+                                records.toSykefraversstatistikkImportDto().tilBehandletStatistikk()
+                            )
+                            logger.info("Lagret ${records.count()} ${kafka.statistikkTopic} meldinger")
 
-                while (job.isActive) {
-                    try {
-                        val records = consumer.poll(Duration.ofSeconds(1))
-                        if (records.count() < 1) continue
-                        logger.info("Fant ${records.count()} nye ${kafka.statistikkTopic} meldinger")
-                        sykefraværsstatistikkService.lagre(
-                            sykefraværsstatistikkListe =
-                            records.toSykefraversstatistikkImportDto().tilBehandletStatistikk()
-                        )
-                        logger.info("Lagret ${records.count()} ${kafka.statistikkTopic} meldinger")
-
-                        consumer.commitSync()
-                    } catch (e: RetriableException) {
-                        logger.warn("Had a retriable exception for ${kafka.statistikkTopic} topic, retrying", e)
-                    } catch (e: Exception) {
-                        logger.error("Exception is shutting down kafka listner for ${kafka.statistikkTopic}", e)
-                        job.cancel(CancellationException(e.message))
-                        throw e
+                            consumer.commitSync()
+                            delay(kafka.consumerLoopDelay)
+                        } catch (e: RetriableException) {
+                            logger.warn("Had a retriable exception for ${kafka.statistikkTopic} topic, retrying", e)
+                        }
                     }
-
-                    delay(kafka.consumerLoopDelay)
+                } catch (e: WakeupException) {
+                    logger.info("Consumer is shutting down...")
+                } catch (e: Exception) {
+                    logger.error("Exception is shutting down kafka listner for ${kafka.statistikkTopic}", e)
                 }
-
             }
         }
     }
@@ -107,9 +104,10 @@ object StatistikkConsumer : CoroutineScope, Helsesjekk {
         return job.isActive
     }
 
-    fun cancel() {
+    fun cancel() = runBlocking {
         logger.info("Stopping kafka consumer job for ${kafka.statistikkTopic}")
-        job.cancel()
+        kafkaConsumer.wakeup()
+        job.cancelAndJoin()
         logger.info("Stopped kafka consumer job for ${kafka.statistikkTopic}")
     }
 

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkConsumer.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkConsumer.kt
@@ -71,7 +71,7 @@ object StatistikkConsumer : CoroutineScope, Helsesjekk {
                         delay(kafka.consumerLoopDelay)
                     }
                 } catch (e: WakeupException) {
-                    logger.info("Consumer is shutting down...")
+                    logger.info("StatistikkConsumer is shutting down...")
                 } catch (e: Exception) {
                     logger.error("Exception is shutting down kafka listner for ${kafka.statistikkTopic}", e)
                     throw e

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkPerKategoriConsumer.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkPerKategoriConsumer.kt
@@ -70,7 +70,7 @@ object StatistikkPerKategoriConsumer : CoroutineScope, Helsesjekk {
                         delay(kafka.consumerLoopDelay)
                     }
                 } catch (e: WakeupException) {
-                    logger.info("Consumer is shutting down...")
+                    logger.info("StatistikkPerKategoriConsumer is shutting down...")
                 } catch (e: Exception) {
                     logger.error("Exception is shutting down kafka listner i StatistikkPerKategoriConsumer", e)
                     throw e

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkPerKategoriConsumer.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkPerKategoriConsumer.kt
@@ -46,14 +46,15 @@ object StatistikkPerKategoriConsumer : CoroutineScope, Helsesjekk {
     fun run() {
         launch {
             kafkaConsumer.use { consumer ->
-                consumer.subscribe(
-                    listOf(
-                        kafka.statistikkLandTopic,
-                        kafka.statistikkVirksomhetTopic
-                    )
-                )
-                logger.info("Kafka consumer subscribed to ${kafka.statistikkLandTopic} and ${kafka.statistikkVirksomhetTopic} i StatistikkPerKategoriConsumer")
                 try {
+                    consumer.subscribe(
+                        listOf(
+                            kafka.statistikkLandTopic,
+                            kafka.statistikkVirksomhetTopic
+                        )
+                    )
+                    logger.info("Kafka consumer subscribed to ${kafka.statistikkLandTopic} and ${kafka.statistikkVirksomhetTopic} i StatistikkPerKategoriConsumer")
+
                     while (job.isActive) {
                         try {
                             val records = consumer.poll(Duration.ofSeconds(1))


### PR DESCRIPTION
Hello peeps 🤩 Long time no see!

I prosessen hvor jeg lærer meg mer om Kafka har jeg fått litt mer innsikt i graceful shutdown av Kafka-consumers. Da kom jeg på at jeg har jo gjort litt kode her som kan forbedres 😉 Så jeg har gjort en liten refaktoring av konsumentene hvor wakeup-metodene kalles, samtidig som exception av wakeup catches og logger shutdown. Deretter vil consumentene closes og coroutine-scopet bli cancelled.

Fordelen er at når applikasjonen tas ned vil alle ressurser stenges ned først, slik at man forhindrer resource-leaks og får en graceful shutdown.

Ref: [https://kafka.apache.org/24/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html](https://kafka.apache.org/24/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html) 