### PR TITLE
Import statistikk (både siste 4 kvartaler og gjeldende kvartal) for sektor fra nytt topic

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,7 +66,7 @@ jobs:
         cluster: [ dev ]
     name: "Deploy app to ${{ matrix.cluster }}"
     needs: "build"
-    if: github.ref == 'refs/heads/import-sf-statistikk-land-siste-kvartal-fra-ny-topic'
+    if: github.ref == 'refs/heads/import-statistikk-4-siste-kvartaler-sektor'
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -75,6 +75,8 @@ spec:
       value: arbeidsgiver.sykefravarsstatistikk-v1
     - name: STATISTIKK_LAND_TOPIC
       value: arbeidsgiver.sykefravarsstatistikk-land-v1
+    - name: STATISTIKK_SEKTOR_TOPIC
+      value: arbeidsgiver.sykefravarsstatistikk-sektor-v1
     - name: STATISTIKK_VIRKSOMHET_TOPIC
       value: arbeidsgiver.sykefravarsstatistikk-virksomhet-v1
     - name: BRREG_UNDERENHET_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
       KAFKA_CREDSTORE_PASSWORD: ""
       STATISTIKK_TOPIC: arbeidsgiver.sykefravarsstatistikk-v1
       STATISTIKK_LAND_TOPIC: arbeidsgiver.sykefravarsstatistikk-land-v1
+      STATISTIKK_SEKTOR_TOPIC: arbeidsgiver.sykefravarsstatistikk-sektor-v1
       STATISTIKK_VIRKSOMHET_TOPIC: arbeidsgiver.sykefravarsstatistikk-virksomhet-v1
       IA_SAK_TOPIC: pia.ia-sak-v1
       IA_SAK_STATISTIKK_TOPIC: pia.ia-sak-statistikk-v1

--- a/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
+++ b/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
@@ -81,6 +81,7 @@ class Kafka(
     val brregOppdateringTopic: String = getEnvVar("BRREG_OPPDATERING_TOPIC"),
     val statistikkTopic: String = getEnvVar("STATISTIKK_TOPIC"),
     val statistikkLandTopic: String = getEnvVar("STATISTIKK_LAND_TOPIC"),
+    val statistikkSektorTopic: String = getEnvVar("STATISTIKK_SEKTOR_TOPIC"),
     val statistikkVirksomhetTopic: String = getEnvVar("STATISTIKK_VIRKSOMHET_TOPIC"),
     val consumerLoopDelay: Long = getEnvVar("CONSUMER_LOOP_DELAY").toLong()
 ) {

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder
 import kotliquery.*
 import no.nav.lydia.sykefraversstatistikk.import.*
 import no.nav.lydia.sykefraversstatistikk.import.SykefraversstatistikkPerKategoriImportDto.Companion.tilBehandletLandSykefraværsstatistikk
+import no.nav.lydia.sykefraversstatistikk.import.SykefraversstatistikkPerKategoriImportDto.Companion.tilBehandletSektorSykefraværsstatistikk
 import javax.sql.DataSource
 
 class SykefraversstatistikkRepository(val dataSource: DataSource) {
@@ -27,6 +28,18 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
             session.transaction { tx ->
                 tx.insertBehandletLandStatistikk(
                     behandletLandSykefraværsstatistikk = sykefraværsstatistikk.tilBehandletLandSykefraværsstatistikk()
+                )
+            }
+        }
+    }
+
+    fun insertSykefraværsstatistikkForSisteGjelendeKvartalForSektor(
+        sykefraværsstatistikk: List<SykefraversstatistikkPerKategoriImportDto>
+    ) {
+        using(sessionOf(dataSource)) { session ->
+            session.transaction { tx ->
+                tx.insertBehandletSektorStatistikk(
+                    behandletSektorSykefraværsstatistikk = sykefraværsstatistikk.tilBehandletSektorSykefraværsstatistikk()
                 )
             }
         }

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
@@ -189,8 +189,6 @@ private fun TransactionalSession.insertBehandletImportStatistikk(behandletImport
     insertVirksomhetsstatistikk(behandletVirksomhetStatistikkListe = behandletImportStatistikkListe.map { it.virksomhetSykefravær })
     insertMetadataForVirksomhet(behandletImportStatistikk = behandletImportStatistikkListe)
 
-    insertBehandletSektorStatistikk(behandletSektorSykefraværsstatistikk = behandletImportStatistikkListe.map { it.sektorSykefravær }
-        .toSet())
     insertBehandletNæringsStatistikk(behandletNæringSykefraværsstatistikk = behandletImportStatistikkListe.map { it.næringSykefravær }
         .toSet())
     insertBehandletNæringsundergruppeStatistikk(behandletNæringsundergruppeSykefraværsstatistikk = behandletImportStatistikkListe.flatMap { it.næring5SifferSykefravær }

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
@@ -18,8 +18,7 @@ import no.nav.lydia.sykefraversstatistikk.domene.VirksomhetsstatistikkSiste4Kvar
 import no.nav.lydia.sykefraversstatistikk.domene.Virksomhetsoversikt
 import no.nav.lydia.sykefraversstatistikk.domene.VirksomhetsstatistikkSisteKvartal
 import no.nav.lydia.sykefraversstatistikk.import.BehandletImportStatistikk
-import no.nav.lydia.sykefraversstatistikk.import.Kategori.LAND
-import no.nav.lydia.sykefraversstatistikk.import.Kategori.VIRKSOMHET
+import no.nav.lydia.sykefraversstatistikk.import.Kategori.*
 import no.nav.lydia.sykefraversstatistikk.import.Kvartal
 import no.nav.lydia.sykefraversstatistikk.import.SykefraversstatistikkPerKategoriImportDto
 import org.slf4j.LoggerFactory
@@ -51,6 +50,10 @@ class SykefraværsstatistikkService(
         sykefraversstatistikkRepository.insertSykefraværsstatistikkForSisteGjelendeKvartalForLand(
             sykefraværsstatistikk = sykefraværsstatistikkKategoriImportDtoListe
                 .filter { it.kategori == LAND }
+        )
+        sykefraversstatistikkRepository.insertSykefraværsstatistikkForSisteGjelendeKvartalForSektor(
+            sykefraværsstatistikk = sykefraværsstatistikkKategoriImportDtoListe
+                .filter { it.kategori == SEKTOR }
         )
     }
 

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkPerKategoriConsumer.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkPerKategoriConsumer.kt
@@ -50,6 +50,7 @@ object StatistikkPerKategoriConsumer : CoroutineScope, Helsesjekk {
                     consumer.subscribe(
                         listOf(
                             kafka.statistikkLandTopic,
+                            kafka.statistikkSektorTopic,
                             kafka.statistikkVirksomhetTopic
                         )
                     )

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkPerKategoriConsumer.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkPerKategoriConsumer.kt
@@ -54,7 +54,7 @@ object StatistikkPerKategoriConsumer : CoroutineScope, Helsesjekk {
                             kafka.statistikkVirksomhetTopic
                         )
                     )
-                    logger.info("Kafka consumer subscribed to ${kafka.statistikkLandTopic} and ${kafka.statistikkVirksomhetTopic} i StatistikkPerKategoriConsumer")
+                    logger.info("Kafka consumer subscribed to ${kafka.statistikkLandTopic}, ${kafka.statistikkSektorTopic} and ${kafka.statistikkVirksomhetTopic} in StatistikkPerKategoriConsumer")
 
                     while (job.isActive) {
                         try {
@@ -67,7 +67,7 @@ object StatistikkPerKategoriConsumer : CoroutineScope, Helsesjekk {
                                 consumer.commitSync()
                             }
                         } catch (e: RetriableException) {
-                            logger.warn("Had a retriable exception i StatistikkPerKategoriConsumer, retrying", e)
+                            logger.warn("Had a retriable exception in StatistikkPerKategoriConsumer, retrying", e)
                         }
                         delay(kafka.consumerLoopDelay)
                     }

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkPerKategoriImportDto.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkPerKategoriImportDto.kt
@@ -32,10 +32,29 @@ data class SykefraversstatistikkPerKategoriImportDto(
                     kode = this.kode,
                 )
             )
+        private fun SykefraversstatistikkPerKategoriImportDto.tilBehandletSektorSykefraværsstatistikk() =
+            BehandletSektorSykefraværsstatistikk(
+                statistikk = SektorSykefravær(
+                    årstall = this.sistePubliserteKvartal.årstall,
+                    kvartal = this.sistePubliserteKvartal.kvartal,
+                    prosent = this.sistePubliserteKvartal.prosent ?: 0.0,
+                    muligeDagsverk = this.sistePubliserteKvartal.muligeDagsverk ?: 0.0,
+                    antallPersoner = this.sistePubliserteKvartal.antallPersoner?.toDouble() ?: 0.0,
+                    tapteDagsverk = this.sistePubliserteKvartal.tapteDagsverk ?: 0.0,
+                    maskert = this.sistePubliserteKvartal.erMaskert,
+                    kategori = this.kategori.name,
+                    kode = this.kode,
+                )
+            )
 
         fun List<SykefraversstatistikkPerKategoriImportDto>.tilBehandletLandSykefraværsstatistikk() =
             this.map {
                 it.tilBehandletLandSykefraværsstatistikk()
+            }
+
+        fun List<SykefraversstatistikkPerKategoriImportDto>.tilBehandletSektorSykefraværsstatistikk() =
+            this.map {
+                it.tilBehandletSektorSykefraværsstatistikk()
             }
     }
 }

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkPerKategoriImportDto.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkPerKategoriImportDto.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 import kotlinx.serialization.Serializable
 
 enum class Kategori {
-    VIRKSOMHET, LAND
+    VIRKSOMHET, LAND, SEKTOR
 }
 
 data class SykefraversstatistikkPerKategoriImportDto(

--- a/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkImportTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkImportTest.kt
@@ -21,7 +21,6 @@ import no.nav.lydia.helper.TestData.Companion.LANDKODE_NO
 import no.nav.lydia.helper.TestData.Companion.NÆRING_JORDBRUK
 import no.nav.lydia.helper.TestData.Companion.NÆRING_SKOGBRUK
 import no.nav.lydia.helper.TestData.Companion.SEKTOR_PRIVAT_NÆRINGSVIRKSOMHET
-import no.nav.lydia.helper.TestData.Companion.SEKTOR_STATLIG_FORVALTNING
 import no.nav.lydia.helper.TestData.Companion.SKOGSKJØTSEL
 import no.nav.lydia.helper.TestVirksomhet
 import no.nav.lydia.helper.TestVirksomhet.Companion.TESTVIRKSOMHET_FOR_IMPORT

--- a/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkImportTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkImportTest.kt
@@ -175,10 +175,7 @@ class SykefraversstatistikkImportTest {
 
         kafkaContainer.sendSykefraversstatistikkKafkaMelding(importDto = melding)
 
-        hentStatistikk(tabell = "sykefravar_statistikk_sektor",
-            kolonne = "sektor_kode",
-            kode = SEKTOR_PRIVAT_NÆRINGSVIRKSOMHET,
-            periode = periode1971) shouldBe SEKTOR_PRIVAT_NÆRINGSVIRKSOMHET
+        sjekkIngenDataErFunnetITabell("sykefravar_statistikk_sektor")
         hentStatistikk(tabell = "sykefravar_statistikk_naring",
             kolonne = "naring",
             kode = NÆRING_JORDBRUK,
@@ -206,10 +203,7 @@ class SykefraversstatistikkImportTest {
 
         kafkaContainer.sendSykefraversstatistikkKafkaMelding(importDto = melding)
 
-        hentStatistikk(tabell = "sykefravar_statistikk_sektor",
-            kolonne = "sektor_kode",
-            kode = SEKTOR_PRIVAT_NÆRINGSVIRKSOMHET,
-            periode = periode1972) shouldBe SEKTOR_PRIVAT_NÆRINGSVIRKSOMHET
+        sjekkIngenDataErFunnetITabell("sykefravar_statistikk_sektor")
         hentStatistikk(tabell = "sykefravar_statistikk_naring",
             kolonne = "naring",
             kode = NÆRING_SKOGBRUK,
@@ -228,11 +222,10 @@ class SykefraversstatistikkImportTest {
     @Test
     fun `sjekk at importmodel er riktig`() {
         val periode = Periode(kvartal = 1, årstall = 2019)
+
         kafkaContainer.sendKafkameldingSomString()
-        hentStatistikk(tabell = "sykefravar_statistikk_sektor",
-            kolonne = "sektor_kode",
-            kode = SEKTOR_STATLIG_FORVALTNING,
-            periode = periode) shouldBe SEKTOR_STATLIG_FORVALTNING
+
+        sjekkIngenDataErFunnetITabell("sykefravar_statistikk_sektor")
         hentStatistikk(tabell = "sykefravar_statistikk_naring",
             kolonne = "naring",
             kode = NÆRING_JORDBRUK,

--- a/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkPerKategoriImportGjeldendeKvartalTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkPerKategoriImportGjeldendeKvartalTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.lydia.Kafka
 import no.nav.lydia.helper.KafkaContainerHelper
 import no.nav.lydia.helper.TestContainerHelper
+import no.nav.lydia.helper.TestData.Companion.SEKTOR_PRIVAT_NÆRINGSVIRKSOMHET
 import no.nav.lydia.sykefraversstatistikk.import.Kategori
 import no.nav.lydia.sykefraversstatistikk.import.Kvartal
 import java.math.BigDecimal
@@ -59,19 +60,19 @@ class SykefraversstatistikkPerKategoriImportGjeldendeKvartalTest {
         TestContainerHelper.postgresContainer.performUpdate("""
             DELETE FROM sykefravar_statistikk_sektor 
             WHERE 
-                sektor_kode = '3' 
+                sektor_kode = '$SEKTOR_PRIVAT_NÆRINGSVIRKSOMHET' 
                 and arstall = ${gjeldendeKvartal.årstall}
                 and kvartal = ${gjeldendeKvartal.kvartal}
         """.trimIndent())
         kafkaContainer.sendOgVentTilKonsumert(
             jsonKey(
                 Kategori.SEKTOR,
-                "3",
+                SEKTOR_PRIVAT_NÆRINGSVIRKSOMHET,
                 gjeldendeKvartal
             ),
             jsonValue(
                 Kategori.SEKTOR,
-                "3",
+                SEKTOR_PRIVAT_NÆRINGSVIRKSOMHET,
                 gjeldendeKvartal,
                 false,
                 BigDecimal(125000.0),
@@ -87,7 +88,7 @@ class SykefraversstatistikkPerKategoriImportGjeldendeKvartalTest {
             """
                 select antall_personer from sykefravar_statistikk_sektor
                 where 
-                sektor_kode = '3' 
+                sektor_kode = '$SEKTOR_PRIVAT_NÆRINGSVIRKSOMHET' 
                 and arstall = ${gjeldendeKvartal.årstall}
                 and kvartal = ${gjeldendeKvartal.kvartal}
             """.trimIndent()

--- a/src/test/kotlin/no/nav/lydia/helper/KafkaContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/KafkaContainerHelper.kt
@@ -47,6 +47,7 @@ class KafkaContainerHelper(
     companion object {
         const val statistikkTopic = "arbeidsgiver.sykefravarsstatistikk-v1"
         const val statistikkLandTopic = "arbeidsgiver.sykefravarsstatistikk-land-v1"
+        const val statistikkSektorTopic = "arbeidsgiver.sykefravarsstatistikk-sektor-v1"
         const val statistikkVirksomhetTopic = "arbeidsgiver.sykefravarsstatistikk-virksomhet-v1"
         const val iaSakTopic = "pia.ia-sak-v1"
         const val iaSakStatistikkTopic = "pia.ia-sak-statistikk-v1"
@@ -82,6 +83,7 @@ class KafkaContainerHelper(
                 iaSakTopic,
                 brregOppdateringTopic,
                 statistikkLandTopic,
+                statistikkSektorTopic,
                 statistikkVirksomhetTopic)
             kafkaProducer = producer()
         }
@@ -95,6 +97,7 @@ class KafkaContainerHelper(
             iaSakLeveranseTopic = iaSakLeveranseTopic,
             statistikkTopic = statistikkTopic,
             statistikkLandTopic = statistikkLandTopic,
+            statistikkSektorTopic = statistikkSektorTopic,
             statistikkVirksomhetTopic = statistikkVirksomhetTopic,
             brregOppdateringTopic = brregOppdateringTopic,
             consumerLoopDelay = 1,
@@ -113,6 +116,7 @@ class KafkaContainerHelper(
         "KAFKA_CREDSTORE_PASSWORD" to "",
         "STATISTIKK_TOPIC" to statistikkTopic,
         "STATISTIKK_LAND_TOPIC" to statistikkLandTopic,
+        "STATISTIKK_SEKTOR_TOPIC" to statistikkSektorTopic,
         "STATISTIKK_VIRKSOMHET_TOPIC" to statistikkVirksomhetTopic,
         "IA_SAK_TOPIC" to iaSakTopic,
         "IA_SAK_STATISTIKK_TOPIC" to iaSakStatistikkTopic,


### PR DESCRIPTION
Endringer: 
 - konfig for å ta i bruk topic sykefravarsstatistikk-sektor-v1 
 - import av statistikk for siste 4 kvartaler i tabell "sykefravar_statistikk_kategori_siste_4_kvartal" 
 - import av statistikk for gjeldende kvartal i tabell "sykefravar_statistikk_sektor"
 - slette import av statistikk for gjeldende kvartal for "Sektor" fra legacy topic "sykefravarsstatistikk-v1"