### PR TITLE
Import statistikk metadata

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,7 +66,7 @@ jobs:
         cluster: [ dev ]
     name: "Deploy app to ${{ matrix.cluster }}"
     needs: "build"
-    if: github.ref == 'refs/heads/import-statistikk-naring'
+    if: github.ref == 'refs/heads/import-statistikk-metadata'
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -73,6 +73,8 @@ spec:
       value: pia.brreg-oppdatering
     - name: STATISTIKK_TOPIC
       value: arbeidsgiver.sykefravarsstatistikk-v1
+    - name: STATISTIKK_METADATA_VIRKSOMHET_TOPIC
+      value: arbeidsgiver.sykefravarsstatistikk-metadata-virksomhet-v1
     - name: STATISTIKK_LAND_TOPIC
       value: arbeidsgiver.sykefravarsstatistikk-land-v1
     - name: STATISTIKK_SEKTOR_TOPIC

--- a/src/main/kotlin/no/nav/lydia/App.kt
+++ b/src/main/kotlin/no/nav/lydia/App.kt
@@ -52,6 +52,7 @@ import no.nav.lydia.sykefraversstatistikk.import.StatistikkConsumer
 import no.nav.lydia.sykefraversstatistikk.import.StatistikkPerKategoriConsumer
 import no.nav.lydia.integrasjoner.azure.AzureService
 import no.nav.lydia.integrasjoner.azure.navEnhet
+import no.nav.lydia.sykefraversstatistikk.import.StatistikkMetadataVirksomhetConsumer
 import no.nav.lydia.virksomhet.VirksomhetRepository
 import no.nav.lydia.virksomhet.VirksomhetService
 import no.nav.lydia.virksomhet.api.VIRKSOMHET_PATH
@@ -87,6 +88,11 @@ fun startLydiaBackend() {
     brregConsumer(naisEnv = naisEnv, dataSource = dataSource)
 
     StatistikkPerKategoriConsumer.apply {
+        create(kafka = naisEnv.kafka, sykefraværsstatistikkService = sykefraværsstatistikkService)
+        run()
+    }.also { HelseMonitor.leggTilHelsesjekk(it) }
+
+    StatistikkMetadataVirksomhetConsumer.apply {
         create(kafka = naisEnv.kafka, sykefraværsstatistikkService = sykefraværsstatistikkService)
         run()
     }.also { HelseMonitor.leggTilHelsesjekk(it) }

--- a/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
+++ b/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
@@ -80,6 +80,7 @@ class Kafka(
     val iaSakLeveranseTopic: String = getEnvVar("IA_SAK_LEVERANSE_TOPIC"),
     val brregOppdateringTopic: String = getEnvVar("BRREG_OPPDATERING_TOPIC"),
     val statistikkTopic: String = getEnvVar("STATISTIKK_TOPIC"),
+    val statistikkMetadataVirksomhetTopic: String = getEnvVar("STATISTIKK_METADATA_VIRKSOMHET_TOPIC"),
     val statistikkLandTopic: String = getEnvVar("STATISTIKK_LAND_TOPIC"),
     val statistikkSektorTopic: String = getEnvVar("STATISTIKK_SEKTOR_TOPIC"),
     val statistikkNæringTopic: String = getEnvVar("STATISTIKK_NARING_TOPIC"),
@@ -89,6 +90,7 @@ class Kafka(
     companion object {
         const val statistikkConsumerGroupId = "lydia-api-kafka-group-id"
         const val statistikkPerKategoriGroupId = "lydia-api-statistikk-per-kategori-consumer"
+        const val statistikkMetadataVirksomhetGroupId = "lydia-api-statistikk-metadata-virksomhet-consumer"
         const val brregConsumerGroupId = "lydia-api-brreg-oppdatering-consumer"
         const val clientId: String = "lydia-api"
     }

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SistePubliseringService.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SistePubliseringService.kt
@@ -20,27 +20,6 @@ class SistePubliseringService(
         val logger = LoggerFactory.getLogger(this::class.java)
     }
 
-    //private val deserializer = Json { ignoreUnknownKeys = true }
-
-    /*
-    fun hentPubliseringsinfo(): Either<Feil, PeriodeDto> {
-        return "https://arbeidsgiver.nav.no/sykefravarsstatistikk/api/publiseringsdato".httpGet().useHttpCache(true)
-            .header(HttpHeaders.Accept to "application/json", HttpHeaders.ContentType to "application/json")
-            .response()
-            .third
-            .fold(success = {
-                it.toString(Charsets.UTF_8).right()
-                deserializer.decodeFromString<Publiseringsinfo>(it.toString(Charsets.UTF_8)).gjeldendePeriode.right()
-            }, failure = {
-                throw IOException(
-                    "Feilet under henting av publiseringsdato: ${it.message} ${
-                        it.errorData.toString(
-                            Charsets.UTF_8
-                        )
-                    }"
-                )
-            })
-    }*/
 
     fun hentPubliseringsinfo(): Either<Feil, Publiseringsinfo> {
         val publiseringsinfo = try {

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraversstatistikkRepository.kt
@@ -194,34 +194,6 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
         }
     }
 
-    private fun TransactionalSession.insertMetadataForVirksomhet(behandletImportStatistikk: List<BehandletImportStatistikk>) =
-        behandletImportStatistikk.forEach { sykefraværsStatistikk ->
-            run(
-                queryOf(
-                    """
-                            INSERT INTO virksomhet_statistikk_metadata(
-                                orgnr,
-                                kategori,
-                                sektor
-                            )
-                            VALUES(
-                                :orgnr,
-                                :kategori,
-                                :sektor
-                            )
-                            ON CONFLICT (orgnr) DO UPDATE SET
-                                kategori = :kategori,
-                                sektor = :sektor
-                        """.trimIndent(),
-                    mapOf(
-                        "orgnr" to sykefraværsStatistikk.virksomhetSykefravær.orgnr,
-                        "kategori" to sykefraværsStatistikk.virksomhetSykefravær.kategori,
-                        "sektor" to sykefraværsStatistikk.sektorSykefravær.sektor
-                    )
-                ).asUpdate
-            )
-        }
-
     private fun BehandletKvartalsvisSykefraværsstatistikk.tilStatistikkSpesifikkVerdi() = when (this) {
         is BehandletLandSykefraværsstatistikk -> this.land
         is BehandletNæringSykefraværsstatistikk -> this.næring
@@ -232,7 +204,6 @@ class SykefraversstatistikkRepository(val dataSource: DataSource) {
 
     private fun TransactionalSession.insertBehandletImportStatistikk(behandletImportStatistikkListe: List<BehandletImportStatistikk>) {
         insertVirksomhetsstatistikk(behandletVirksomhetStatistikkListe = behandletImportStatistikkListe.map { it.virksomhetSykefravær })
-        insertMetadataForVirksomhet(behandletImportStatistikk = behandletImportStatistikkListe)
 
         insertBehandletNæringsundergruppeStatistikk(behandletNæringsundergruppeSykefraværsstatistikk = behandletImportStatistikkListe.flatMap { it.næring5SifferSykefravær }
             .toSet())

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
@@ -17,11 +17,8 @@ import no.nav.lydia.sykefraversstatistikk.api.Søkeparametere
 import no.nav.lydia.sykefraversstatistikk.domene.VirksomhetsstatistikkSiste4Kvartal
 import no.nav.lydia.sykefraversstatistikk.domene.Virksomhetsoversikt
 import no.nav.lydia.sykefraversstatistikk.domene.VirksomhetsstatistikkSisteKvartal
-import no.nav.lydia.sykefraversstatistikk.import.BehandletImportStatistikk
-import no.nav.lydia.sykefraversstatistikk.import.Kategori
+import no.nav.lydia.sykefraversstatistikk.import.*
 import no.nav.lydia.sykefraversstatistikk.import.Kategori.*
-import no.nav.lydia.sykefraversstatistikk.import.Kvartal
-import no.nav.lydia.sykefraversstatistikk.import.SykefraversstatistikkPerKategoriImportDto
 import org.slf4j.LoggerFactory
 import java.time.LocalDate.now
 
@@ -36,6 +33,12 @@ class SykefraværsstatistikkService(
         val start = System.currentTimeMillis()
         sykefraversstatistikkRepository.insert(behandletImportStatistikkListe = sykefraværsstatistikkListe)
         log.info("Brukte ${System.currentTimeMillis() - start} ms på å lagre statistikk for ${sykefraværsstatistikkListe.size} virksomheter")
+    }
+
+    fun lagreStatistikkMetadataVirksomhet(behandletImportMetadataVirksomhetListe: List<BehandletImportMetadataVirksomhet>) {
+        sykefraversstatistikkRepository.insertMetadataForVirksomhet(
+            behandletImportMetadataVirksomhetListe
+        )
     }
 
     fun lagreSykefraværsstatistikkPerKategori(

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
@@ -63,9 +63,6 @@ class SykefraværsstatistikkService(
     }
 
     private fun lagreSykefraværsstatistikkSiste4Kvartal(sykefraværsstatistikkKategoriImportDtoListe: List<SykefraversstatistikkPerKategoriImportDto>) {
-        sykefraværsstatistikkKategoriImportDtoListe.forEach {
-            println("[DEBUG] Got following statistics ${it.kode}/${it.kategori}")
-        }
         sykefraversstatistikkRepository.insertSykefraværsstatistikkForSiste4KvartalerForVirksomhet(
             sykefraværsstatistikk = sykefraværsstatistikkKategoriImportDtoListe
                 .filter { it.kategori == VIRKSOMHET }

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/SykefraværsstatistikkService.kt
@@ -36,9 +36,14 @@ class SykefraværsstatistikkService(
     }
 
     fun lagreStatistikkMetadataVirksomhet(behandletImportMetadataVirksomhetListe: List<BehandletImportMetadataVirksomhet>) {
+        if (behandletImportMetadataVirksomhetListe.isNotEmpty()) {
+            log.info("Lagrer ${behandletImportMetadataVirksomhetListe.size} rad(er) med metadata virksomhet")
+        }
+        val start = System.currentTimeMillis()
         sykefraversstatistikkRepository.insertMetadataForVirksomhet(
             behandletImportMetadataVirksomhetListe
         )
+        log.info("Brukte ${System.currentTimeMillis() - start} ms på å lagre ${behandletImportMetadataVirksomhetListe.size} virksomhet metadata")
     }
 
     fun lagreSykefraværsstatistikkPerKategori(
@@ -146,14 +151,6 @@ class SykefraværsstatistikkService(
 
         return sykefraværForVirksomhetSisteKvartal?.right()
             ?: SykefraværsstatistikkError.`ingen sykefraværsstatistikk`.left()
-    }
-
-    fun hentGjeldendePeriodeSiste4Kvartal(): Either<Feil, KvartalerFraTil> {
-        val gjeldendePeriode = sistePubliseringService.hentGjelendePeriode()
-        return KvartalerFraTil(
-            fra = gjeldendePeriode.forrigePeriode().forrigePeriode().forrigePeriode().tilKvartal(),
-            til = gjeldendePeriode.tilKvartal()
-        ).right()
     }
 }
 

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/BehandletImportMetadataVirksomhet.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/BehandletImportMetadataVirksomhet.kt
@@ -19,7 +19,7 @@ data class BehandletImportMetadataVirksomhet (
                 orgnr = this.orgnr,
                 kvartal = Kvartal(this.årstall, this.kvartal),
                 naring = this.naring,
-                bransje = this.bransje,
+                bransje = this.bransje?: "",
                 sektor = this.sektor.fraSykefraværsstistikkSektortilSektor() ?:
                 throw IllegalStateException("Sektor '${this.sektor}' funnet i import av metadata virksomhet. " +
                         "Denne skal ikke importeres. Sektor skal være en av " +

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/BehandletImportMetadataVirksomhet.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/BehandletImportMetadataVirksomhet.kt
@@ -1,0 +1,44 @@
+package no.nav.lydia.sykefraversstatistikk.import
+
+import no.nav.lydia.virksomhet.domene.Sektor
+import java.lang.IllegalStateException
+
+private val SEKTOR_FRA_SYKEFRAVÆRSSTATISTIKK_TIL_IMPORT = listOf("STATLIG", "KOMMUNAL", "PRIVAT")
+
+data class BehandletImportMetadataVirksomhet (
+    val orgnr: String,
+    val kvartal: Kvartal,
+    val naring: String,
+    val bransje: String,
+    val sektor: Sektor,
+) {
+
+    companion object {
+        fun SykefraversstatistikkMetadataVirksomhetImportDto.tilBehandletImportMetadataVirksomhet() =
+            BehandletImportMetadataVirksomhet(
+                orgnr = this.orgnr,
+                kvartal = Kvartal(this.årstall, this.kvartal),
+                naring = this.naring,
+                bransje = this.bransje,
+                sektor = this.sektor.fraSykefraværsstistikkSektortilSektor() ?:
+                throw IllegalStateException("Sektor '${this.sektor}' funnet i import av metadata virksomhet. " +
+                        "Denne skal ikke importeres. Sektor skal være en av " +
+                        SEKTOR_FRA_SYKEFRAVÆRSSTATISTIKK_TIL_IMPORT.joinToString(separator = ", ")
+                )
+            )
+
+        fun List<SykefraversstatistikkMetadataVirksomhetImportDto>.tilBehandletImportMetadataVirksomhet() =
+            this.filter { dto ->
+                dto.sektor.isNotEmpty() && SEKTOR_FRA_SYKEFRAVÆRSSTATISTIKK_TIL_IMPORT.contains(dto.sektor)
+            }.map { it.tilBehandletImportMetadataVirksomhet() }
+    }
+}
+
+fun String.fraSykefraværsstistikkSektortilSektor(): Sektor? {
+    return when (this) {
+        "STATLIG" -> Sektor.STATLIG
+        "KOMMUNAL" -> Sektor.KOMMUNAL
+        "PRIVAT" -> Sektor.PRIVAT
+        else -> null
+    }
+}

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkMetadataVirksomhetConsumer.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/StatistikkMetadataVirksomhetConsumer.kt
@@ -1,0 +1,100 @@
+package no.nav.lydia.sykefraversstatistikk.import
+
+import com.google.gson.GsonBuilder
+import kotlinx.coroutines.*
+import no.nav.lydia.Kafka
+import no.nav.lydia.appstatus.Helse
+import no.nav.lydia.appstatus.Helsesjekk
+import no.nav.lydia.sykefraversstatistikk.SykefraværsstatistikkService
+import no.nav.lydia.sykefraversstatistikk.import.BehandletImportMetadataVirksomhet.Companion.tilBehandletImportMetadataVirksomhet
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.errors.RetriableException
+import org.apache.kafka.common.errors.WakeupException
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import kotlin.coroutines.CoroutineContext
+
+object StatistikkMetadataVirksomhetConsumer : CoroutineScope, Helsesjekk {
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    lateinit var job: Job
+    lateinit var kafka: Kafka
+    private lateinit var sykefraværsstatistikkService: SykefraværsstatistikkService
+    private lateinit var kafkaConsumer: KafkaConsumer<String, String>
+
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.IO + job
+
+    init {
+        Runtime.getRuntime().addShutdownHook(Thread(StatistikkMetadataVirksomhetConsumer::cancel))
+    }
+
+    fun create(kafka: Kafka, sykefraværsstatistikkService: SykefraværsstatistikkService) {
+        logger.info("Creating kafka consumer job i StatistikkMetadataVirksomhetConsumer")
+        this.job = Job()
+        this.sykefraværsstatistikkService = sykefraværsstatistikkService
+        this.kafka = kafka
+        this.kafkaConsumer = KafkaConsumer(
+            StatistikkMetadataVirksomhetConsumer.kafka.consumerProperties(consumerGroupId = Kafka.statistikkMetadataVirksomhetGroupId),
+            StringDeserializer(),
+            StringDeserializer()
+        )
+        logger.info("Created kafka consumer job i StatistikkMetadataVirksomhetConsumer")
+    }
+
+    fun run() {
+        launch {
+            kafkaConsumer.use { consumer ->
+                try {
+                    consumer.subscribe(listOf(kafka.statistikkMetadataVirksomhetTopic))
+                    logger.info("Kafka consumer subscribed to ${kafka.statistikkMetadataVirksomhetTopic} in StatistikkMetadataVirksomhetConsumer")
+
+                    while (job.isActive) {
+                        try {
+                            val records = consumer.poll(Duration.ofSeconds(1))
+                            if (!records.isEmpty) {
+                                sykefraværsstatistikkService.lagreStatistikkMetadataVirksomhet(
+                                    records.toSykefraversstatistikkMetadataVirksomhetImportDto().tilBehandletImportMetadataVirksomhet()
+                                )
+                                logger.info("Lagret ${records.count()} meldinger om i StatistikkMetadataVirksomhetConsumer")
+                                consumer.commitSync()
+                            }
+                        } catch (e: RetriableException) {
+                            logger.warn("Had a retriable exception in StatistikkMetadataVirksomhetConsumer, retrying", e)
+                        }
+                        delay(kafka.consumerLoopDelay)
+                    }
+                } catch (e: WakeupException) {
+                    logger.info("StatistikkMetadataVirksomhetConsumer is shutting down...")
+                } catch (e: Exception) {
+                    logger.error("Exception is shutting down kafka listner i StatistikkMetadataVirksomhetConsumer", e)
+                    throw e
+                }
+            }
+        }
+    }
+
+    fun cancel() = runBlocking {
+        logger.info("Stopping kafka consumer job i StatistikkMetadataVirksomhetConsumer")
+        kafkaConsumer.wakeup()
+        job.cancelAndJoin()
+        logger.info("Stopped kafka consumer job i StatistikkMetadataVirksomhetConsumer")
+    }
+
+    private fun ConsumerRecords<String, String>.toSykefraversstatistikkMetadataVirksomhetImportDto():
+            List<SykefraversstatistikkMetadataVirksomhetImportDto> {
+        val gson = GsonBuilder().create()
+        return this.map {
+            gson.fromJson(
+                it.value(),
+                SykefraversstatistikkMetadataVirksomhetImportDto::class.java
+            )
+        }
+    }
+
+    fun isRunning() = job.isActive
+
+    override fun helse() = if (isRunning()) Helse.UP else Helse.DOWN
+}

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkMetadataVirksomhetImportDto.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkMetadataVirksomhetImportDto.kt
@@ -12,7 +12,7 @@ data class SykefraversstatistikkMetadataVirksomhetImportDto(
     @SerializedName("naring")
     val naring: String,
     @SerializedName("bransje")
-    val bransje: String,
+    val bransje: String?,
     @SerializedName("sektor")
     val sektor: String,
 )

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkMetadataVirksomhetImportDto.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkMetadataVirksomhetImportDto.kt
@@ -1,0 +1,18 @@
+package no.nav.lydia.sykefraversstatistikk.import
+
+import com.google.gson.annotations.SerializedName
+
+data class SykefraversstatistikkMetadataVirksomhetImportDto(
+    @SerializedName("orgnr")
+    val orgnr: String,
+    @SerializedName("arstall") // OBS: feltet er 'årstall' og ikke 'arstall' i sykefravarsstatistikk-metadata-virksomhet-v1
+    val årstall: Int,
+    @SerializedName("kvartal")
+    val kvartal: Int,
+    @SerializedName("naring")
+    val naring: String,
+    @SerializedName("bransje")
+    val bransje: String,
+    @SerializedName("sektor")
+    val sektor: String,
+)

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkMetadataVirksomhetImportDto.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/import/SykefraversstatistikkMetadataVirksomhetImportDto.kt
@@ -16,3 +16,9 @@ data class SykefraversstatistikkMetadataVirksomhetImportDto(
     @SerializedName("sektor")
     val sektor: String,
 )
+
+data class KeySykefraversstatistikkMetadataVirksomhet(
+    val orgnr: String,
+    val arstall: Int,
+    val kvartal: Int,
+)

--- a/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkImportTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkImportTest.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.container.sykefraversstatistikk
 
-import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -102,16 +101,6 @@ class SykefraversstatistikkImportTest {
         andreLagredeStatistikkSiste4Kvartal.muligeDagsverk shouldBe førsteLagredeStatistikkSiste4Kvartal.muligeDagsverk
         andreLagredeStatistikkSiste4Kvartal.tapteDagsverk shouldBe førsteLagredeStatistikkSiste4Kvartal.tapteDagsverk
         andreLagredeStatistikkSisteKvartal.antallPersoner shouldBe førsteLagredeStatistikkSisteKvartal.antallPersoner
-    }
-
-    @Test
-    fun `vi lagrer metadata ved import`() {
-        kafkaContainer.sendSykefraversstatistikkKafkaMelding(SykefraværsstatistikkTestData.testVirksomhetForrigeKvartal.sykefraværsstatistikkImportDto)
-
-        val antallMetadata =
-            postgres.hentEnkelKolonne<Int>("SELECT count(*) FROM virksomhet_statistikk_metadata WHERE orgnr = '${TESTVIRKSOMHET_FOR_IMPORT.orgnr}'")
-
-        antallMetadata shouldBeGreaterThanOrEqual 1
     }
 
     @Test

--- a/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkMetadataVirksomhetImportTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkMetadataVirksomhetImportTest.kt
@@ -1,0 +1,149 @@
+package no.nav.lydia.container.sykefraversstatistikk
+
+import io.kotest.matchers.shouldBe
+import no.nav.lydia.Kafka
+import no.nav.lydia.helper.KafkaContainerHelper
+import no.nav.lydia.helper.TestContainerHelper
+import no.nav.lydia.sykefraversstatistikk.import.Kategori
+import no.nav.lydia.sykefraversstatistikk.import.Kvartal
+import no.nav.lydia.virksomhet.domene.Sektor
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class SykefraversstatistikkMetadataVirksomhetImportTest {
+    private val kafkaContainer = TestContainerHelper.kafkaContainerHelper
+    private val KVARTAL_2022_4 = Kvartal(2022, 4)
+
+    @BeforeTest
+    fun cleanUp() {
+
+        TestContainerHelper.postgresContainer.performUpdate(
+            """
+            delete from virksomhet_statistikk_metadata
+        """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `vi lagrer sykefraværsstatistikk metadata for virksomhet`() {
+        kafkaContainer.sendOgVentTilKonsumert(
+            jsonKey("999999999"),
+            jsonValue(orgnr = "999999999", sektor = "KOMMUNAL"),
+            KafkaContainerHelper.statistikkMetadataVirksomhetTopic,
+            Kafka.statistikkMetadataVirksomhetGroupId
+        )
+
+        TestContainerHelper.postgresContainer.hentEnkelKolonne<String>(
+            sql =
+            """
+                select sektor from virksomhet_statistikk_metadata
+                where orgnr = '999999999'
+            """.trimIndent()
+        ) shouldBe Sektor.KOMMUNAL.kode
+    }
+
+    @Test
+    fun `sykefraværsstatistikk metadata for virksomhet med ukjent sektor blir ignorert`() {
+        kafkaContainer.sendOgVentTilKonsumert(
+            jsonKey("999999999"),
+            jsonValue(orgnr = "999999999", sektor = "STATLIG"),
+            KafkaContainerHelper.statistikkMetadataVirksomhetTopic,
+            Kafka.statistikkMetadataVirksomhetGroupId
+        )
+        kafkaContainer.sendOgVentTilKonsumert(
+            jsonKey("888888888"),
+            jsonValue(orgnr = "888888888", sektor = "FYLKESKOMMUNAL_FORVALTNING"),
+            KafkaContainerHelper.statistikkMetadataVirksomhetTopic,
+            Kafka.statistikkMetadataVirksomhetGroupId
+        )
+
+        val results = hentMetadataVirksomhet()
+        results.size shouldBe 1
+        val virksomhetMetadata = results.first()
+        virksomhetMetadata.sektor shouldBe Sektor.STATLIG.kode
+        virksomhetMetadata.kategori shouldBe Kategori.VIRKSOMHET.name
+        virksomhetMetadata.orgnr shouldBe "999999999"
+    }
+
+    @Test
+    fun `sykefraværsstatistikk metadata for virksomhet oppdaterer`() {
+        kafkaContainer.sendOgVentTilKonsumert(
+            jsonKey("999999999"),
+            jsonValue(orgnr = "999999999", sektor = "STATLIG"),
+            KafkaContainerHelper.statistikkMetadataVirksomhetTopic,
+            Kafka.statistikkMetadataVirksomhetGroupId
+        )
+        kafkaContainer.sendOgVentTilKonsumert(
+            jsonKey("999999999"),
+            jsonValue(orgnr = "999999999", sektor = "PRIVAT"),
+            KafkaContainerHelper.statistikkMetadataVirksomhetTopic,
+            Kafka.statistikkMetadataVirksomhetGroupId
+        )
+
+        val results = hentMetadataVirksomhet()
+        results.size shouldBe 1
+        val virksomhetMetadata = results.first()
+        virksomhetMetadata.sektor shouldBe Sektor.PRIVAT.kode
+        virksomhetMetadata.kategori shouldBe Kategori.VIRKSOMHET.name
+        virksomhetMetadata.orgnr shouldBe "999999999"
+    }
+
+
+    private fun jsonKey(
+        orgnr: String,
+        kvartal: Kvartal = KVARTAL_2022_4
+    ) =
+        """
+      {
+        "orgnr": "$orgnr",
+        "arstall": ${kvartal.årstall},
+        "kvartal": ${kvartal.kvartal}
+      }
+""".trimIndent()
+
+    private fun jsonValue(
+        orgnr: String,
+        kvartal: Kvartal = KVARTAL_2022_4,
+        næring: String = "88",
+        bransje: String = "BARNEHAGER",
+        sektor: String = Sektor.PRIVAT.name,
+    ): String {
+        return """{
+        "orgnr": "$orgnr",
+        "arstall": ${kvartal.årstall},
+        "kvartal": ${kvartal.kvartal},
+        "naring": $næring,
+        "bransje": $bransje,
+        "sektor": $sektor
+      }
+""".trimIndent()
+    }
+
+    private fun hentMetadataVirksomhet(): List<VirksomhetMetadata> {
+        val query = """
+            select * from virksomhet_statistikk_metadata
+        """.trimMargin()
+        TestContainerHelper.postgresContainer.dataSource.connection.use { connection ->
+            val statement = connection.createStatement()
+            statement.execute(query)
+            val rs = statement.resultSet
+            val list = mutableListOf<VirksomhetMetadata>()
+            while (rs.next()) {
+                list.add(
+                    VirksomhetMetadata(
+                        orgnr = rs.getString("orgnr"),
+                        kategori = rs.getString("kategori"),
+                        sektor = rs.getString("sektor")
+                    )
+                )
+            }
+            return list
+        }
+    }
+
+    private data class VirksomhetMetadata(
+        val orgnr: String,
+        val kategori: String,
+        val sektor: String
+    )
+}

--- a/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkMetadataVirksomhetImportTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraversstatistikk/SykefraversstatistikkMetadataVirksomhetImportTest.kt
@@ -117,10 +117,14 @@ class SykefraversstatistikkMetadataVirksomhetImportTest {
     }
 
     private fun hentMetadataVirksomhet(vararg orgnr: String): List<VirksomhetMetadata> {
+        var filter = ""
+        if (orgnr.size > 0) {
         val orgnrListe = orgnr.joinToString(transform =  { nummer: String -> "'$nummer'" }, separator = ",")
+            filter = "where orgnr in ($orgnrListe)"
+        }
         val query = """
             select * from virksomhet_statistikk_metadata
-            where orgnr in ($orgnrListe)
+            $filter
         """.trimMargin()
         TestContainerHelper.postgresContainer.dataSource.connection.use { connection ->
             val statement = connection.createStatement()

--- a/src/test/kotlin/no/nav/lydia/helper/KafkaContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/KafkaContainerHelper.kt
@@ -46,6 +46,7 @@ class KafkaContainerHelper(
 ) {
     companion object {
         const val statistikkTopic = "arbeidsgiver.sykefravarsstatistikk-v1"
+        const val statistikkMetadataVirksomhetTopic = "arbeidsgiver.sykefravarsstatistikk-metadata-virksomhet-v1"
         const val statistikkLandTopic = "arbeidsgiver.sykefravarsstatistikk-land-v1"
         const val statistikkSektorTopic = "arbeidsgiver.sykefravarsstatistikk-sektor-v1"
         const val statistikkNæringTopic = "arbeidsgiver.sykefravarsstatistikk-naring-v1"
@@ -80,9 +81,11 @@ class KafkaContainerHelper(
         .apply {
             start()
             adminClient = AdminClient.create(mapOf(BOOTSTRAP_SERVERS_CONFIG to this.bootstrapServers))
-            createTopic(statistikkTopic,
+            createTopic(
+                statistikkTopic,
                 iaSakTopic,
                 brregOppdateringTopic,
+                statistikkMetadataVirksomhetTopic,
                 statistikkLandTopic,
                 statistikkSektorTopic,
                 statistikkVirksomhetTopic)
@@ -97,6 +100,7 @@ class KafkaContainerHelper(
             iaSakStatusTopic = iaSakStatusTopic,
             iaSakLeveranseTopic = iaSakLeveranseTopic,
             statistikkTopic = statistikkTopic,
+            statistikkMetadataVirksomhetTopic = statistikkMetadataVirksomhetTopic,
             statistikkLandTopic = statistikkLandTopic,
             statistikkSektorTopic = statistikkSektorTopic,
             statistikkNæringTopic = statistikkNæringTopic,
@@ -118,6 +122,7 @@ class KafkaContainerHelper(
         "KAFKA_CREDSTORE_PASSWORD" to "",
         "STATISTIKK_TOPIC" to statistikkTopic,
         "STATISTIKK_LAND_TOPIC" to statistikkLandTopic,
+        "STATISTIKK_METADATA_VIRKSOMHET_TOPIC" to statistikkMetadataVirksomhetTopic,
         "STATISTIKK_SEKTOR_TOPIC" to statistikkSektorTopic,
         "STATISTIKK_NARING_TOPIC" to statistikkNæringTopic,
         "STATISTIKK_VIRKSOMHET_TOPIC" to statistikkVirksomhetTopic,

--- a/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
@@ -844,6 +844,10 @@ class VirksomhetHelper {
             TestContainerHelper.kafkaContainerHelper.sendSykefraversstatistikkPerKategoriIBulkOgVentTilKonsumert(
                 testData.sykefraværsstatistikkPerKategoriMeldinger().toList()
             )
+
+            TestContainerHelper.kafkaContainerHelper.sendStatistikkMetadataVirksomhetIBulkOgVentTilKonsumert(
+                testData.sykefraværsstatistikkMetadataVirksomhetKafkaMeldinger().toList()
+            )
         }
     }
 }

--- a/src/test/kotlin/no/nav/lydia/helper/TestData.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestData.kt
@@ -7,6 +7,8 @@ import no.nav.lydia.helper.TestData.Companion.NÆRING_JORDBRUK
 import no.nav.lydia.sykefraversstatistikk.api.Periode
 import no.nav.lydia.sykefraversstatistikk.import.*
 import no.nav.lydia.virksomhet.domene.Næringsgruppe
+import no.nav.lydia.virksomhet.domene.Sektor
+import no.nav.lydia.virksomhet.domene.tilSektor
 import kotlin.random.Random
 
 const val MAX_SYKEFRAVÆRSPROSENT = 20
@@ -50,6 +52,8 @@ class TestData(
     private val kafkaMeldinger = mutableSetOf<SykefraversstatistikkImportDto>()
     private val sykefraværsstatistikkPerKategoriKafkaMeldinger =
         mutableSetOf<SykefraversstatistikkPerKategoriImportDto>()
+    private val sykefraværsstatistikkMetadataVirksomhetKafkaMeldinger =
+        mutableSetOf<SykefraversstatistikkMetadataVirksomhetImportDto>()
     private val næringer = mutableSetOf<String>()
     private val brregVirksomheter = mutableSetOf<String>()
 
@@ -136,6 +140,16 @@ class TestData(
                     tapteDagsverk = tapteDagsverk,
                 )
             )
+            sykefraværsstatistikkMetadataVirksomhetKafkaMeldinger.add(
+                SykefraversstatistikkMetadataVirksomhetImportDto(
+                    orgnr = virksomhet.orgnr,
+                    årstall = periode.årstall,
+                    kvartal = periode.kvartal,
+                    sektor = sektor.tilSektor()?.name ?: Sektor.STATLIG.name,
+                    bransje = "BARNEHAGER",
+                    naring = "88"
+                )
+            )
         }
         virksomhet.næringsundergrupper
             .map(Næringsgruppe::tilTosifret)
@@ -154,6 +168,9 @@ class TestData(
 
     fun sykefraværsstatistikkPerKategoriMeldinger() =
         sykefraværsstatistikkPerKategoriKafkaMeldinger
+
+    fun sykefraværsstatistikkMetadataVirksomhetKafkaMeldinger() =
+        sykefraværsstatistikkMetadataVirksomhetKafkaMeldinger
 
     fun brregMockData() =
         brregVirksomheter.joinToString(prefix = "[", postfix = "]", separator = ",")

--- a/src/test/kotlin/no/nav/lydia/sykefraversstatistikk/import/BehandletImportMetadataVirksomhetTest.kt
+++ b/src/test/kotlin/no/nav/lydia/sykefraversstatistikk/import/BehandletImportMetadataVirksomhetTest.kt
@@ -1,0 +1,78 @@
+package no.nav.lydia.sykefraversstatistikk.import
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import no.nav.lydia.sykefraversstatistikk.import.BehandletImportMetadataVirksomhet.Companion.tilBehandletImportMetadataVirksomhet
+import no.nav.lydia.virksomhet.domene.Sektor
+import java.lang.IllegalStateException
+import kotlin.test.Test
+
+class BehandletImportMetadataVirksomhetTest {
+
+    @Test
+    fun `Metadata virksomhet uten gyldig sektor skal ikke kunne mappes direkte til BehandletImportMetadataVirksomhet`() {
+        assertSektorIkkeStøttesTilImport("")
+        assertSektorIkkeStøttesTilImport("UKJENT")
+        // T.O. det er forelløpig ingen bedrift med FYLKESKOMMUNAL_FORVALTNING i import data
+        assertSektorIkkeStøttesTilImport("FYLKESKOMMUNAL_FORVALTNING")
+    }
+
+    @Test
+    fun `Metadata virksomhet uten gyldig sektor filtreres vekk og blir ikke importert`() {
+        val result = listOf(
+            SykefraversstatistikkMetadataVirksomhetImportDto(
+                sektor = "",
+                årstall = 2023,
+                kvartal = 2,
+                orgnr = "999999999",
+                naring = "41",
+                bransje = "BYGG"
+            ),
+            SykefraversstatistikkMetadataVirksomhetImportDto(
+                sektor = "FYLKESKOMMUNAL_FORVALTNING",
+                årstall = 2023,
+                kvartal = 2,
+                orgnr = "888888888",
+                naring = "41",
+                bransje = "BYGG"
+            ),
+            SykefraversstatistikkMetadataVirksomhetImportDto(
+                sektor = "PRIVAT",
+                årstall = 2023,
+                kvartal = 2,
+                orgnr = "777777777",
+                naring = "49",
+                bransje = "TRANSPORT"
+            ),
+            SykefraversstatistikkMetadataVirksomhetImportDto(
+                sektor = "UKJENT",
+                årstall = 2023,
+                kvartal = 2,
+                orgnr = "666666666",
+                naring = "49",
+                bransje = "TRANSPORT"
+            )
+        ).tilBehandletImportMetadataVirksomhet()
+
+        result.size shouldBe 1
+        result[0].orgnr shouldBe "777777777"
+        result[0].sektor shouldBe Sektor.PRIVAT
+    }
+
+
+    private fun assertSektorIkkeStøttesTilImport(sektor: String) {
+        val exceptionFordiSektorIkkeStøttesTilImport = shouldThrow<IllegalStateException> {
+            SykefraversstatistikkMetadataVirksomhetImportDto(
+                sektor = sektor,
+                årstall = 2023,
+                kvartal = 2,
+                orgnr = "999999999",
+                naring = "41",
+                bransje = "BYGG"
+            ).tilBehandletImportMetadataVirksomhet()
+        }
+
+        exceptionFordiSektorIkkeStøttesTilImport.message shouldStartWith "Sektor '$sektor' funnet i import"
+    }
+}


### PR DESCRIPTION
Endringer:
 - konfig for å ta i bruk topic sykefravarsstatistikk-metadata-virksomhet-v1
 - ny Kafka consumer som leser fra topic og lagre metadata i eksisterende tabell
 - fjerne koden som gjorde import fra legacy topic
