### PR TITLE
Filtrering under/over bransjegjennomsnitt

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}
     name: "Deploy app to dev"
     needs: "build"
-    if: github.ref == 'refs/heads/oppdatere-siste-publisert-kvartal'
+    if: github.ref == 'refs/heads/samenligning-med-bransje'
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/VirksomhetsinformasjonRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/VirksomhetsinformasjonRepository.kt
@@ -67,8 +67,9 @@ class VirksomhetsinformasjonRepository(val dataSource: DataSource) {
                 ${
                     if (søkeparametere.snittFilter == SnittFilter.BRANSJE_NÆRING_OVER
                             || søkeparametere.snittFilter == SnittFilter.BRANSJE_NÆRING_UNDER_ELLER_LIK) {
-                              " JOIN sykefravar_statistikk_kategori_siste_4_kvartal AS naring_siste4" +
-                                      " on (substr(vn.naringsundergruppe1, 1, 2) = naring_siste4.kode AND kategori = 'NÆRING') "
+                              " JOIN sykefravar_statistikk_kategori_siste_4_kvartal AS naring_siste4 on (substr(vn.naringsundergruppe1, 1, 2) = naring_siste4.kode AND naring_siste4.kategori = 'NÆRING')" +
+                                      " LEFT JOIN naringsundergrupper_per_bransje AS bransjeprogram on (vn.naringsundergruppe1 = bransjeprogram.naringsundergruppe)" +
+                                      " LEFT JOIN sykefravar_statistikk_kategori_siste_4_kvartal AS bransje_siste4 on (bransjeprogram.bransje = bransje_siste4.kode AND bransje_siste4.kategori = 'BRANSJE') "
                             } else ""
                 }
                 
@@ -144,8 +145,9 @@ class VirksomhetsinformasjonRepository(val dataSource: DataSource) {
                 ${
                     if (søkeparametere.snittFilter == SnittFilter.BRANSJE_NÆRING_OVER 
                             || søkeparametere.snittFilter == SnittFilter.BRANSJE_NÆRING_UNDER_ELLER_LIK) {
-                              " JOIN sykefravar_statistikk_kategori_siste_4_kvartal AS naring_siste4" +
-                                      " on (substr(vn.naringsundergruppe1, 1, 2) = naring_siste4.kode AND kategori = 'NÆRING') "
+                              " JOIN sykefravar_statistikk_kategori_siste_4_kvartal AS naring_siste4 on (substr(vn.naringsundergruppe1, 1, 2) = naring_siste4.kode AND naring_siste4.kategori = 'NÆRING')" +
+                                      " LEFT JOIN naringsundergrupper_per_bransje AS bransjeprogram on (vn.naringsundergruppe1 = bransjeprogram.naringsundergruppe)" +
+                                      " LEFT JOIN sykefravar_statistikk_kategori_siste_4_kvartal AS bransje_siste4 on (bransjeprogram.bransje = bransje_siste4.kode AND bransje_siste4.kategori = 'BRANSJE') "                        
                             } else ""
                 }
                 

--- a/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/api/Søkeparametere.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraversstatistikk/api/Søkeparametere.kt
@@ -131,11 +131,19 @@ data class Søkeparametere(
                     when (snittFilter) {
                         SnittFilter.BRANSJE_NÆRING_OVER ->
                         """
-                            AND statistikk_siste4.prosent > naring_siste4.prosent
+                            AND (
+                              (bransje_siste4.prosent is null AND statistikk_siste4.prosent > naring_siste4.prosent) 
+                                OR 
+                              (bransje_siste4.prosent is not null AND statistikk_siste4.prosent > bransje_siste4.prosent)
+                            ) 
                         """.trimIndent()
                         SnittFilter.BRANSJE_NÆRING_UNDER_ELLER_LIK ->
                             """
-                            AND statistikk_siste4.prosent <= naring_siste4.prosent
+                            AND (
+                              (bransje_siste4.prosent is null AND statistikk_siste4.prosent <= naring_siste4.prosent) 
+                                OR 
+                              (bransje_siste4.prosent is null AND statistikk_siste4.prosent <= bransje_siste4.prosent)
+                            )
                         """.trimIndent()
                         else ->
                             ""

--- a/src/main/resources/db/migration/V54__naringsundergrupper_per_bransje_tabell.sql
+++ b/src/main/resources/db/migration/V54__naringsundergrupper_per_bransje_tabell.sql
@@ -1,0 +1,121 @@
+create table naringsundergrupper_per_bransje
+(
+    naringsundergruppe varchar primary key,
+    bransje            varchar not null,
+    opprettet          timestamp default current_timestamp
+);
+create index idx_bransje_naringsundergrupper_per_bransje on naringsundergrupper_per_bransje (bransje);
+
+-- Barnehager
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('88.911', 'BARNEHAGER');
+-- Næringsmiddelindustri
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.110', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.120', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.130', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.201', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.202', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.203', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.209', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.310', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.320', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.390', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.411', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.412', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.413', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.420', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.510', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.520', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.610', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.620', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.710', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.720', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.730', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.810', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.820', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.830', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.840', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.850', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.860', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.890', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.910', 'NÆRINGSMIDDELINDUSTRI');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('10.920', 'NÆRINGSMIDDELINDUSTRI');
+-- Sykehus
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('86.101', 'SYKEHUS');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('86.102', 'SYKEHUS');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('86.104', 'SYKEHUS');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('86.105', 'SYKEHUS');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('86.106', 'SYKEHUS');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('86.107', 'SYKEHUS');
+-- Sykehjem
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('87.101', 'SYKEHJEM');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('87.102', 'SYKEHJEM');
+-- Transport
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('49.100', 'TRANSPORT');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('49.311', 'TRANSPORT');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('49.391', 'TRANSPORT');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('49.392', 'TRANSPORT');
+-- Bygg
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('41.101', 'BYGG');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('41.109', 'BYGG');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('41.200', 'BYGG');
+-- Anlegg
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('42.110', 'ANLEGG');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('42.120', 'ANLEGG');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('42.130', 'ANLEGG');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('42.210', 'ANLEGG');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('42.220', 'ANLEGG');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('42.910', 'ANLEGG');
+insert into naringsundergrupper_per_bransje(naringsundergruppe, bransje)
+VALUES ('42.990', 'ANLEGG');

--- a/src/test/kotlin/no/nav/lydia/helper/TestData.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestData.kt
@@ -19,6 +19,7 @@ class TestData(
         const val BRANSJE_NÆRINGSMIDDELINDUSTRI = "Næringsmiddelindustri"
         const val NÆRING_JORDBRUK = "01"
         const val NÆRING_SKOGBRUK = "02"
+        const val NÆRING_PLEIE_OG_OMSORGSTJENESTER_I_INSTITUSJON = "87"
         const val NÆRINGSKODE_BARNEHAGER = "88911"
 
         val DYRKING_AV_KORN = Næringsgruppe(kode = "$NÆRING_JORDBRUK.110", navn = "Dyrking av korn, unntatt ris")


### PR DESCRIPTION
Endringer som gjør at det er nå mulig å filtrere på over/under bransjegjennomsnitt
 - ny tabell `naringsundergrupper_per_bransje` som inneholder/kartlegger mappingen næringsundergruppe <-> bransje. Denne tabellen gjør det mulig å hente med en SQL spøring bransje til en næringsundergruppe
 - utvidet SQL spørring for `hentVirksomheter` slik at den joiner på 
  -- `naringsundergrupper_per_bransje` via `naeringsundergruppe1` i tabellen `virksomhet_naringsundergrupper`
  -- `sykefravar_statistikk_kategori_siste_4_kvartal` (kategori bransje) 
