### PR TITLE
Håndtere ny format for Sektor statistikk. Feltet 'kategori' er fortsa…

### DIFF
--- a/src/main/kotlin/no/nav/lydia/sykefraværsstatistikk/SykefraværsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/lydia/sykefraværsstatistikk/SykefraværsstatistikkService.kt
@@ -22,6 +22,8 @@ import no.nav.lydia.sykefraværsstatistikk.domene.VirksomhetsstatistikkSiste4Kva
 import no.nav.lydia.sykefraværsstatistikk.domene.VirksomhetsstatistikkSisteKvartal
 import no.nav.lydia.sykefraværsstatistikk.import.*
 import no.nav.lydia.sykefraværsstatistikk.import.Kategori.*
+import no.nav.lydia.sykefraværsstatistikk.import.SykefraværsstatistikkPerKategoriImportDto.Companion.filterPåKategoriSektorOgGyldigSektor
+import no.nav.lydia.sykefraværsstatistikk.import.SykefraværsstatistikkPerKategoriImportDto.Companion.mapSektorNavnTilSektorKode
 import no.nav.lydia.virksomhet.VirksomhetRepository
 import org.slf4j.LoggerFactory
 import java.time.LocalDate.now
@@ -95,8 +97,19 @@ class SykefraværsstatistikkService(
             sykefraværsstatistikk = sykefraværsstatistikkForVirksomheter
         )
 
+        val sykefraværsstatistikkForSektor = sykefraværsstatistikkKategoriImportDtoListe
+            .filterPåKategoriSektorOgGyldigSektor()
+            .mapSektorNavnTilSektorKode()
+
+        if (sykefraværsstatistikkForSektor.isNotEmpty()) {
+            log.info("Lagrer ${sykefraværsstatistikkForSektor.size} rad(er) med statistikk for SEKTOR i siste 4 kvartal")
+        }
+        sykefraværsstatistikkRepository.insertSykefraværsstatistikkForSiste4KvartalerForAndreKategorier(
+            sykefraværsstatistikk = sykefraværsstatistikkForSektor
+        )
+
         val sykefraværsstatistikkForAndreKategorier = sykefraværsstatistikkKategoriImportDtoListe
-            .filter { it.kategori != VIRKSOMHET }
+            .filter { it.kategori != VIRKSOMHET && it.kategori != SEKTOR }
 
         if (sykefraværsstatistikkForAndreKategorier.isNotEmpty()) {
             log.info("Lagrer ${sykefraværsstatistikkForAndreKategorier.size} rad(er) med statistikk for andre kategorier i siste 4 kvartal")

--- a/src/main/kotlin/no/nav/lydia/virksomhet/domene/Sektor.kt
+++ b/src/main/kotlin/no/nav/lydia/virksomhet/domene/Sektor.kt
@@ -8,9 +8,15 @@ enum class Sektor(val kode: String, val beskrivelse: String) {
 
 fun String.tilSektor(): Sektor? {
     return when (this) {
-        "1" -> Sektor.STATLIG
-        "2" -> Sektor.KOMMUNAL
-        "3" -> Sektor.PRIVAT
+        Sektor.STATLIG.kode -> Sektor.STATLIG
+        Sektor.STATLIG.name -> Sektor.STATLIG
+        Sektor.KOMMUNAL.kode -> Sektor.KOMMUNAL
+        Sektor.KOMMUNAL.name -> Sektor.KOMMUNAL
+        Sektor.PRIVAT.kode -> Sektor.PRIVAT
+        Sektor.PRIVAT.name -> Sektor.PRIVAT
         else -> null
     }
 }
+
+fun String.erGyldigSektor(): Boolean =
+    this.tilSektor() != null

--- a/src/test/kotlin/no/nav/lydia/sykefraværsstatistikk/import/SykefraværsstatistikkPerKategoriImportDtoTest.kt
+++ b/src/test/kotlin/no/nav/lydia/sykefraværsstatistikk/import/SykefraværsstatistikkPerKategoriImportDtoTest.kt
@@ -1,0 +1,66 @@
+package no.nav.lydia.sykefraværsstatistikk.import
+
+import io.kotest.matchers.shouldBe
+import no.nav.lydia.container.sykefraværsstatistikk.importering.SykefraværsstatistikkImportTestUtils
+import no.nav.lydia.sykefraværsstatistikk.import.SykefraværsstatistikkPerKategoriImportDto.Companion.filterPåKategoriSektorOgGyldigSektor
+import no.nav.lydia.virksomhet.domene.Sektor
+import kotlin.test.Test
+
+class SykefraværsstatistikkPerKategoriImportDtoTest {
+
+    @Test
+    fun `filterPåKategoriSektorOgGyldigSektor filtrerer bort ugyldige sektorer`() {
+        listOf(
+            SykefraværsstatistikkPerKategoriImportDto(
+                kategori = Kategori.SEKTOR,
+                kode = "Not OK",
+                sistePubliserteKvartal = sistePubliserteKvartal,
+                siste4Kvartal = siste4Kvartal
+            ),
+            SykefraværsstatistikkPerKategoriImportDto(
+                kategori = Kategori.SEKTOR,
+                kode = Sektor.KOMMUNAL.name,
+                sistePubliserteKvartal = sistePubliserteKvartal,
+                siste4Kvartal = siste4Kvartal
+            )
+        ).filterPåKategoriSektorOgGyldigSektor().size shouldBe 1
+    }
+
+    @Test
+    fun `filterPåKategoriSektorOgGyldigSektor filtrerer bort det som ikke er SEKTOR`() {
+        listOf(
+            SykefraværsstatistikkPerKategoriImportDto(
+                kategori = Kategori.VIRKSOMHET,
+                kode = "987654321",
+                sistePubliserteKvartal = sistePubliserteKvartal,
+                siste4Kvartal = siste4Kvartal
+            ),
+            SykefraværsstatistikkPerKategoriImportDto(
+                kategori = Kategori.BRANSJE,
+                kode = "BARNEHAGER",
+                sistePubliserteKvartal = sistePubliserteKvartal,
+                siste4Kvartal = siste4Kvartal
+            )
+        ).filterPåKategoriSektorOgGyldigSektor().size shouldBe 0
+    }
+
+
+    private val sistePubliserteKvartal: SistePubliserteKvartal =
+        SistePubliserteKvartal(
+            årstall = SykefraværsstatistikkImportTestUtils.KVARTAL_2023_1.årstall,
+            kvartal = SykefraværsstatistikkImportTestUtils.KVARTAL_2023_1.kvartal,
+            tapteDagsverk = 504339.8,
+            muligeDagsverk = 10104849.1,
+            prosent = 6.0,
+            erMaskert = false,
+            antallPersoner = 3000001
+        )
+    private val siste4Kvartal: Siste4Kvartal =
+        Siste4Kvartal(
+            tapteDagsverk = 31505774.2,
+            muligeDagsverk = 578099000.3,
+            prosent = 5.4,
+            erMaskert = false,
+            kvartaler = listOf(SykefraværsstatistikkImportTestUtils.KVARTAL_2023_1)
+        )
+}

--- a/src/test/kotlin/no/nav/lydia/virksomhet/domene/SektorKtTest.kt
+++ b/src/test/kotlin/no/nav/lydia/virksomhet/domene/SektorKtTest.kt
@@ -1,0 +1,15 @@
+package no.nav.lydia.virksomhet.domene
+
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+class SektorKtTest {
+
+    @Test
+    fun `tilSektor lager Sektor ut i fra 'navn' eller 'kode'`() {
+        Sektor.entries.forAll {
+          it.name.tilSektor() shouldBe it
+          it.kode.tilSektor() shouldBe it
+        }
+    }
+}


### PR DESCRIPTION
…tt 'SEKTOR', men 'kode' blir en 'STATLIG', 'KOMMUNAL' eller 'PRIVAT' i stedet av 1, 2 og 3.

Vi lagrer fortsatt som før med 1, 2 og 3 som kode i databasen. Ukjente koder blir ikke lagret (vi lagrer ikke lenger 0 som kode da den ikke blir tatt i bruk noen steder)

Denne PR er knyttet denne andre PR i sykefraværsstatistikk-api https://github.com/navikt/sykefravarsstatistikk-api/pull/443 