### PR TITLE
Nye sporsmal partssamarbeid

### DIFF
--- a/src/main/kotlin/no/nav/lydia/ia/sak/domene/Tema.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/domene/Tema.kt
@@ -5,6 +5,7 @@ import kotlinx.datetime.LocalDateTime
 
 data class Tema(
 	val id: Int,
+	val rekkefølge: Int,
 	val navn: Temanavn,
 	val beskrivelse: String,
 	val introtekst: String,

--- a/src/main/kotlin/no/nav/lydia/integrasjoner/kartlegging/KartleggingRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/integrasjoner/kartlegging/KartleggingRepository.kt
@@ -192,6 +192,7 @@ class KartleggingRepository(val dataSource: DataSource) {
                         SELECT ia_sak_kartlegging_tema.* FROM ia_sak_kartlegging_tema
                           JOIN ia_sak_kartlegging_kartlegging_til_tema USING (tema_id)
                           WHERE kartlegging_id = :kartlegging_id
+                          ORDER BY rekkefolge
                     """.trimIndent(),
                     mapOf(
                         "kartlegging_id" to kartleggingId.toString()

--- a/src/main/kotlin/no/nav/lydia/integrasjoner/kartlegging/KartleggingRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/integrasjoner/kartlegging/KartleggingRepository.kt
@@ -116,7 +116,7 @@ class KartleggingRepository(val dataSource: DataSource) {
                     ).asUpdate
                 )
 
-                temaer.forEach { tema ->
+                temaer.sortedBy{ it.rekkefølge }.forEach { tema ->
                     tx.run(
                         queryOf(
                             """
@@ -393,6 +393,7 @@ class KartleggingRepository(val dataSource: DataSource) {
     private fun mapTilTema(row: Row) =
         Tema(
             id = row.int("tema_id"),
+            rekkefølge = row.int("rekkefolge"),
             navn = Temanavn.valueOf(row.string("navn")),
             beskrivelse = row.string("beskrivelse"),
             introtekst = row.string("introtekst"),

--- a/src/main/resources/db/migration/2024/V76__legg_til_rekkefolge_i_kartlegging_tema.sql
+++ b/src/main/resources/db/migration/2024/V76__legg_til_rekkefolge_i_kartlegging_tema.sql
@@ -1,0 +1,3 @@
+alter table ia_sak_kartlegging_tema add column rekkefolge int not null default 0;
+update ia_sak_kartlegging_tema set rekkefolge = 1 where tema_id = 1;
+update ia_sak_kartlegging_tema set rekkefolge = 2 where tema_id = 2;

--- a/src/main/resources/db/migration/2024/V77__nye_sporsmal_til_tema_partssamarbeid.sql
+++ b/src/main/resources/db/migration/2024/V77__nye_sporsmal_til_tema_partssamarbeid.sql
@@ -1,0 +1,141 @@
+-- spm 1
+insert into ia_sak_kartlegging_sporsmal (sporsmal_id, sporsmal_tekst)
+VALUES ('018e7b0a-4455-739d-b377-870e01fe978f',
+        'Hvor lenge har du vært en del av gruppen?');
+
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0a-4455-739d-b377-870e01fe978f', 'Mindre enn et år');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0a-4455-739d-b377-870e01fe978f', '1-2 år');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0a-4455-739d-b377-870e01fe978f', '2-4 år');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0a-4455-739d-b377-870e01fe978f', 'Mer enn fire år');
+
+-- spm 2
+insert into ia_sak_kartlegging_sporsmal (sporsmal_id, sporsmal_tekst)
+VALUES ('018e7b0b-2490-7295-9ab4-aca881c46320',
+        'Hvor ofte møtes dere?');
+
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0b-2490-7295-9ab4-aca881c46320', '1 - 2 ganger i året');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0b-2490-7295-9ab4-aca881c46320', '3 - 5 ganger i året');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0b-2490-7295-9ab4-aca881c46320', '6 - 10 ganger i året');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0b-2490-7295-9ab4-aca881c46320', 'Mer enn 10 ganger i året');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0b-2490-7295-9ab4-aca881c46320', 'Vet ikke');
+
+-- spm 3
+
+insert into ia_sak_kartlegging_sporsmal (sporsmal_id, sporsmal_tekst)
+VALUES ('018e7b0d-fe32-79ab-8e2e-b990afbbc2bf',
+        'Hvilke temaer får størst prioritet i møtene deres?');
+
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0d-fe32-79ab-8e2e-b990afbbc2bf', 'Lønnsforhandlinger');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0d-fe32-79ab-8e2e-b990afbbc2bf', 'HMS');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0d-fe32-79ab-8e2e-b990afbbc2bf', 'Bemanning');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0d-fe32-79ab-8e2e-b990afbbc2bf', 'Sykefravær');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0d-fe32-79ab-8e2e-b990afbbc2bf', 'Arbeidsmiljø');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0d-fe32-79ab-8e2e-b990afbbc2bf', 'Annet');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b0d-fe32-79ab-8e2e-b990afbbc2bf', 'Vet ikke');
+
+-- spm 4
+insert into ia_sak_kartlegging_sporsmal (sporsmal_id, sporsmal_tekst)
+VALUES ('018e7b12-b11a-7f68-b617-e694fd010088',
+        'Hvor godt kjenner dere til hverandres roller og ansvar i gruppen?');
+
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b12-b11a-7f68-b617-e694fd010088', 'Godt');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b12-b11a-7f68-b617-e694fd010088', 'Hverken godt eller dårlig');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b12-b11a-7f68-b617-e694fd010088', 'Ikke så godt');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b12-b11a-7f68-b617-e694fd010088', 'Vet ikke');
+
+-- spm 5
+insert into ia_sak_kartlegging_sporsmal (sporsmal_id, sporsmal_tekst)
+VALUES ('018e7b15-256d-705e-a3e9-913e56658b28',
+        'Hvordan opplever du at samarbeidet i gruppen fungerer?');
+
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b15-256d-705e-a3e9-913e56658b28', 'Bra');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b15-256d-705e-a3e9-913e56658b28', 'Hverken bra eller dårlig');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b15-256d-705e-a3e9-913e56658b28', 'Ikke så bra');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b15-256d-705e-a3e9-913e56658b28', 'Vet ikke');
+
+-- spm 6
+insert into ia_sak_kartlegging_sporsmal (sporsmal_id, sporsmal_tekst)
+VALUES ('018e7b17-4004-7c54-a1ab-d352a87be133',
+        'I hvilken grad er du involvert i den daglige driften?');
+
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b17-4004-7c54-a1ab-d352a87be133', 'I stor grad');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b17-4004-7c54-a1ab-d352a87be133', 'I noe grad');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b17-4004-7c54-a1ab-d352a87be133', 'I liten grad');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b17-4004-7c54-a1ab-d352a87be133', 'Vet ikke');
+
+-- spm 7
+insert into ia_sak_kartlegging_sporsmal (sporsmal_id, sporsmal_tekst)
+VALUES ('018e7b18-2552-77e9-95a1-366c3eb8e800',
+        'I hvilken grad er du involvert i å skape godt samarbeid på arbeidsplassen?');
+
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b18-2552-77e9-95a1-366c3eb8e800', 'I stor grad');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b18-2552-77e9-95a1-366c3eb8e800', 'I noe grad');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b18-2552-77e9-95a1-366c3eb8e800', 'I liten grad');
+insert into ia_sak_kartlegging_svaralternativer (svaralternativ_id, sporsmal_id, svaralternativ_tekst)
+VALUES (gen_random_uuid(), '018e7b18-2552-77e9-95a1-366c3eb8e800', 'Vet ikke');
+
+-- Legg til ny versjon av tema PARTSSAMARBEID
+INSERT INTO ia_sak_kartlegging_tema (tema_id, navn, rekkefolge, beskrivelse, introtekst)
+VALUES (3, 'UTVIKLE_PARTSSAMARBEID', 1,
+        'Utvikle partssamarbeidet i virksomheten',
+        'Partssamarbeid er essensielt i virksomheter fordi det bidrar til et godt forebyggende arbeidsmiljø og reduksjon av antall tapte dagsverk. Partssamarbeidet anerkjenner og utnytter kompetansen og ansvarsområdene til verneombud, tillitsvalgte og ledere, noe som skaper en "utvidet ledelseskapasitet".');
+
+-- Legg til alle 7 spørsmål i tema PARTSSAMARBEID
+INSERT INTO ia_sak_kartlegging_tema_til_spørsmål (tema_id, sporsmal_id)
+VALUES (3, '018e7b0a-4455-739d-b377-870e01fe978f');
+
+INSERT INTO ia_sak_kartlegging_tema_til_spørsmål (tema_id, sporsmal_id)
+VALUES (3, '018e7b0b-2490-7295-9ab4-aca881c46320');
+
+INSERT INTO ia_sak_kartlegging_tema_til_spørsmål (tema_id, sporsmal_id)
+VALUES (3, '018e7b0d-fe32-79ab-8e2e-b990afbbc2bf');
+
+INSERT INTO ia_sak_kartlegging_tema_til_spørsmål (tema_id, sporsmal_id)
+VALUES (3, '018e7b12-b11a-7f68-b617-e694fd010088');
+
+INSERT INTO ia_sak_kartlegging_tema_til_spørsmål (tema_id, sporsmal_id)
+VALUES (3, '018e7b15-256d-705e-a3e9-913e56658b28');
+
+INSERT INTO ia_sak_kartlegging_tema_til_spørsmål (tema_id, sporsmal_id)
+VALUES (3, '018e7b17-4004-7c54-a1ab-d352a87be133');
+
+INSERT INTO ia_sak_kartlegging_tema_til_spørsmål (tema_id, sporsmal_id)
+VALUES (3, '018e7b18-2552-77e9-95a1-366c3eb8e800');
+
+-- deaktiver gammelt tema PARTSSAMARBEID med temaId 1
+UPDATE ia_sak_kartlegging_tema SET status = 'INAKTIV' WHERE tema_id = 1;
+
+
+
+

--- a/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/IASakKartleggingApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/IASakKartleggingApiTest.kt
@@ -464,7 +464,7 @@ class IASakKartleggingApiTest {
         oversiktMedAntallSvar.kartleggingId shouldBe kartlegging.kartleggingId
         oversiktMedAntallSvar.antallUnikeDeltakereMedMinstEttSvar shouldBe 2
         oversiktMedAntallSvar.antallUnikeDeltakereSomHarSvartPåAlt shouldBe 1
-        oversiktMedAntallSvar.spørsmålMedAntallSvarPerTema.first().antallSpørsmål shouldBe 3
+        oversiktMedAntallSvar.spørsmålMedAntallSvarPerTema.first().antallSpørsmål shouldBe 7
 
         //-- Flere temaer
         oversiktMedAntallSvar.spørsmålMedAntallSvarPerTema shouldHaveSize 2

--- a/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/IASakKartleggingApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/IASakKartleggingApiTest.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.shouldFail
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.equals.shouldBeEqual
@@ -142,8 +143,11 @@ class IASakKartleggingApiTest {
     fun `skal sende kartlegging på kafka`() {
         val sak = nySakIKartlegges()
 
-        val resp = IASakKartleggingHelper.opprettIASakKartlegging(orgnr = sak.orgnr, saksnummer = sak.saksnummer)
-            .tilSingelRespons<IASakKartleggingDto>()
+        val resp = IASakKartleggingHelper.opprettIASakKartlegging(
+            orgnr = sak.orgnr,
+            saksnummer = sak.saksnummer,
+            temaer = listOf(Temanavn.UTVIKLE_PARTSSAMARBEID)
+        ).tilSingelRespons<IASakKartleggingDto>()
 
         val id = resp.third.get().kartleggingId
 
@@ -159,9 +163,9 @@ class IASakKartleggingApiTest {
                     spørreundersøkelse.status shouldBe KartleggingStatus.OPPRETTET
                     spørreundersøkelse.temaMedSpørsmålOgSvaralternativer shouldHaveSize 1
                     spørreundersøkelse.temaMedSpørsmålOgSvaralternativer.forAll { tema ->
-                        tema.spørsmålOgSvaralternativer shouldHaveSize 3
+                        tema.spørsmålOgSvaralternativer shouldHaveSize 7 // Det er 7 spørsmål i tema UTVIKLE_PARTSSAMARBEID
                         tema.spørsmålOgSvaralternativer.forAll {
-                            it.svaralternativer shouldHaveSize 5
+                            it.svaralternativer shouldHaveAtLeastSize 4 // Det er minst 4 svaralternativer per spørsmål
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/lydia/ia/sak/domene/TemaTest.kt
+++ b/src/test/kotlin/no/nav/lydia/ia/sak/domene/TemaTest.kt
@@ -1,0 +1,18 @@
+package no.nav.lydia.ia.sak.domene
+
+import io.kotest.matchers.collections.shouldContainInOrder
+import java.time.LocalDateTime.now
+import kotlin.test.Test
+import kotlinx.datetime.toKotlinLocalDateTime
+
+
+class TemaTest {
+
+    @Test
+    fun `skal kunne sortere temaer på 'rekkefølge'`() {
+        val tema2 = Tema(2, 2, Temanavn.UTVIKLE_PARTSSAMARBEID, "", "", TemaStatus.AKTIV, sistEndret = now().toKotlinLocalDateTime())
+        val tema3 = Tema(3, 1, Temanavn.REDUSERE_SYKEFRAVÆR, "", "", TemaStatus.AKTIV, sistEndret = now().toKotlinLocalDateTime())
+
+        listOf(tema2, tema3).sortedBy { it.rekkefølge }.shouldContainInOrder(listOf(tema3, tema2))
+    }
+}


### PR DESCRIPTION
Endringer som er gjort her: 

- legg til 7 nye spørsmål i tema "utvikle partssamarbeid"
- deaktivere eksisterende tema "utvikle partssamarbeid"
- opprette et nytt tema "utvikle partssamarbeid" og koble til 7 nye spørsmål
- legg til kolonne 'rekkefolge' i tema tabellen slik at de aktive temaene hentes ut i en bestemt rekkefølge ("utvikle partssamarbeid" først)
- tilpasse tester etter antall spørsmål knyttet til ny versjon av tema "utvikle partssamarbeid"