### PR TITLE
Ny status AVBRUTT fro undertema i en plan

### DIFF
--- a/src/main/kotlin/no/nav/lydia/ia/sak/PlanService.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/PlanService.kt
@@ -148,7 +148,7 @@ object PlanFeil {
         httpStatusCode = HttpStatusCode.BadRequest,
     )
     val `kan ikke endre status til AVBRUTT` = Feil(
-        feilmelding = "Fant ikke tema",
+        feilmelding = "Kan ikke endre status til AVBRUTT",
         httpStatusCode = HttpStatusCode.BadRequest,
     )
     val `feil inndata i forespørsel` = Feil(

--- a/src/main/kotlin/no/nav/lydia/ia/sak/domene/plan/PlanUndertema.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/domene/plan/PlanUndertema.kt
@@ -1,6 +1,9 @@
 package no.nav.lydia.ia.sak.domene.plan
 
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.toJavaLocalDate
+import kotlinx.datetime.toKotlinLocalDate
+import no.nav.lydia.ia.sak.domene.plan.PlanUndertema.Status.AVBRUTT
 
 data class PlanUndertema(
     val id: Int,
@@ -15,5 +18,29 @@ data class PlanUndertema(
         PLANLAGT,
         PÅGÅR,
         FULLFØRT,
+        AVBRUTT
+    }
+
+    fun starterIFremtiden(): Boolean {
+        val iDag = java.time.LocalDate.now()
+        return startDato != null && startDato.toJavaLocalDate().isAfter(iDag)
+                && sluttDato != null && sluttDato.toJavaLocalDate().isAfter(iDag)
+    }
+
+    fun copyMedNyStatus(nyStatus: Status): PlanUndertema {
+        val iDag = java.time.LocalDate.now()
+        var nySluttDato = sluttDato
+
+        if (nyStatus == AVBRUTT
+            && startDato != null && startDato.toJavaLocalDate().isBefore(iDag)
+            && sluttDato != null && sluttDato.toJavaLocalDate().isAfter(iDag)
+        ) {
+            nySluttDato = iDag.toKotlinLocalDate()
+        }
+
+        return copy(
+            status = nyStatus,
+            sluttDato = nySluttDato
+        )
     }
 }


### PR DESCRIPTION
Status AVBRUTT kommer med følgende regler ved "oppdater status": 

- Dersom dagensdato/dato brukeren endrer status til AVBRUTT , er i perioden fra-til i undertemaet, da skal:
  -- sluttDato endres til dagensdato/dato
  -- status blir satt til AVBRUTT
 - Dersom temaet er i fortiden, blir status endret til AVBRUTT
 - Det skal IKKE være mulig å sette status til et temaet som starter i fortiden til AVBRUTT. Endepunkt returnerer BAD REQUEST 