### PR TITLE
Tar i bruk unik kafka produsent på tvers av alle kafkaprodusenter.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,7 +67,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/sf-aktiviteter'
+    if: github.ref == 'refs/heads/unik-klient-id-per-produsent'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
+++ b/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
@@ -191,7 +191,9 @@ enum class Topic(
     ),
     SAMARBEIDSPLAN_TOPIC(
         navn = "pia.samarbeidsplan-v1",
-        groupId = "lydia-api-samarbeidsplan-producer",
+        groupId = "lydia-api-samarbeidsplan",
+        // TODO: Finn en bedre løsning på groupId, dette topicet blir brukt av SamarbeidProudsent og SamarbeidsplanProdusent
+        //  Per nå blir groupId brukt med en post-fix for å gi unik id. groupId bør kanskje settes på hver produsent i stedet.
     ),
     SPORREUNDERSOKELSE_HENDELSE_TOPIC(
         navn = "pia.sporreundersokelse-hendelse-v1",

--- a/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
+++ b/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
@@ -191,7 +191,7 @@ enum class Topic(
     ),
     SAMARBEIDSPLAN_TOPIC(
         navn = "pia.samarbeidsplan-v1",
-        groupId = "lydia-api-samarbeidsplan",
+        groupId = "lydia-api-samarbeidsplan-producer",
     ),
     SPORREUNDERSOKELSE_HENDELSE_TOPIC(
         navn = "pia.sporreundersokelse-hendelse-v1",

--- a/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
+++ b/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
@@ -155,39 +155,39 @@ enum class Topic(
 ) {
     IA_SAK_TOPIC(
         navn = "pia.ia-sak-v1",
-        groupId = "lydia-api-ia-sak-producer-consumer",
+        groupId = "lydia-api-ia-sak-producer",
     ),
     IA_SAK_STATISTIKK_TOPIC(
         navn = "pia.ia-sak-statistikk-v1",
-        groupId = "lydia-api-ia-sak-statistikk-producer-consumer",
+        groupId = "lydia-api-ia-sak-statistikk-producer",
     ),
     IA_SAK_STATUS_TOPIC(
         navn = "pia.ia-sak-status-v1",
-        groupId = "lydia-api-ia-sak-status-producer-consumer",
+        groupId = "lydia-api-ia-sak-status-producer",
     ),
     IA_SAK_LEVERANSE_TOPIC(
         navn = "pia.ia-sak-leveranse-v1",
-        groupId = "lydia-api-ia-sak-leveranse-producer-consumer",
+        groupId = "lydia-api-ia-sak-leveranse-producer",
     ),
     SPORREUNDERSOKELSE_TOPIC(
         navn = "pia.sporreundersokelse-v1",
-        groupId = "lydia-api-sporreundersokelse-comsumer",
+        groupId = "lydia-api-sporreundersokelse-consumer",
     ),
     FULLFØRT_BEHOVSVURDERING_TOPIC(
         navn = "pia.fullfort-behovsvurdering-v1",
-        groupId = "lydia-api-fullfort-behovsvurdering",
+        groupId = "lydia-api-fullfort-behovsvurdering-producer",
     ),
     SPØRREUNDERSØKELSE_BIGQUERY_TOPIC(
         navn = "pia.behovsvurdering-bigquery-v1",
-        groupId = "lydia-api-behovsvurdering-bigquery-producer-consumer",
+        groupId = "lydia-api-behovsvurdering-bigquery-producer",
     ),
     SAMARBEID_BIGQUERY_TOPIC(
         navn = "pia.samarbeid-bigquery-v1",
-        groupId = "lydia-api-samarbeid-bigquery-producer-consumer",
+        groupId = "lydia-api-samarbeid-bigquery-producer",
     ),
     SAMARBEIDSPLAN_BIGQUERY_TOPIC(
         navn = "pia.samarbeidsplan-bigquery-v1",
-        groupId = "lydia-api-samarbeidsplan-bigquery-producer-consumer",
+        groupId = "lydia-api-samarbeidsplan-bigquery-producer",
     ),
     SAMARBEIDSPLAN_TOPIC(
         navn = "pia.samarbeidsplan-v1",

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/FullførtBehovsvurderingProdusent.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/FullførtBehovsvurderingProdusent.kt
@@ -4,45 +4,37 @@ import ia.felles.integrasjoner.kafkameldinger.spørreundersøkelse.Spørreunders
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.toKotlinLocalDateTime
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import no.nav.lydia.Kafka
 import no.nav.lydia.Observer
-import no.nav.lydia.Topic.FULLFØRT_BEHOVSVURDERING_TOPIC
+import no.nav.lydia.Topic
 import no.nav.lydia.ia.sak.domene.spørreundersøkelse.Spørreundersøkelse
 
 class FullførtBehovsvurderingProdusent(
-    private val produsent: KafkaProdusent,
-) : Observer<Spørreundersøkelse> {
+    kafka: Kafka,
+    topic: Topic = Topic.FULLFØRT_BEHOVSVURDERING_TOPIC,
+) : KafkaProdusent<Spørreundersøkelse>(kafka, topic),
+    Observer<Spørreundersøkelse> {
     override fun receive(input: Spørreundersøkelse) {
-        if (input.type == "Behovsvurdering" && input.status == AVSLUTTET) {
-            sendPåKafka(input)
-        }
+        if (input.type == "Behovsvurdering" && input.status == AVSLUTTET) sendPåKafka(input)
     }
 
-    private fun sendPåKafka(spørreundersøkelse: Spørreundersøkelse) {
-        val (nøkkel, melding) = spørreundersøkelse.tilKafkamelding()
-        produsent.sendMelding(
-            topic = FULLFØRT_BEHOVSVURDERING_TOPIC.navn,
-            nøkkel = nøkkel,
-            verdi = melding,
+    override fun tilKafkaMelding(input: Spørreundersøkelse): Pair<String, String> {
+        val nøkkel = input.id.toString()
+        val verdi = FullførtBehovsvurdering(
+            behovsvurderingId = input.id.toString(),
+            saksnummer = input.saksnummer,
+            prosessId = input.samarbeidId.toString(),
+            fullførtTidspunkt = input.endretTidspunkt ?: java.time.LocalDateTime.now().toKotlinLocalDateTime(),
         )
+        return nøkkel to Json.encodeToString(verdi)
     }
 
-    private fun Spørreundersøkelse.tilKafkamelding() =
-        this.id.toString() to Json.encodeToString<FullførtBehovsvurdering>(
-            FullførtBehovsvurdering(
-                behovsvurderingId = this.id.toString(),
-                saksnummer = this.saksnummer,
-                prosessId = this.samarbeidId.toString(),
-                fullførtTidspunkt = this.endretTidspunkt ?: java.time.LocalDateTime.now().toKotlinLocalDateTime(),
-            ),
-        )
+    @Serializable
+    data class FullførtBehovsvurdering(
+        val behovsvurderingId: String,
+        val saksnummer: String,
+        val prosessId: String,
+        val fullførtTidspunkt: LocalDateTime,
+    )
 }
-
-@Serializable
-data class FullførtBehovsvurdering(
-    val behovsvurderingId: String,
-    val saksnummer: String,
-    val prosessId: String,
-    val fullførtTidspunkt: LocalDateTime,
-)

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/IASakStatistikkEksporterer.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/IASakStatistikkEksporterer.kt
@@ -30,7 +30,7 @@ class IASakStatistikkEksporterer(
                 List(hendelser.size) { index ->
                     IASak.fraHendelser(hendelser.subList(0, index + 1))
                 }.forEach { historiskIaSak ->
-                    iaSakStatistikkProdusent.reEksporter(historiskIaSak)
+                    iaSakStatistikkProdusent.receive(historiskIaSak)
                 }
             }
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/IASakStatusProdusent.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/IASakStatusProdusent.kt
@@ -18,7 +18,6 @@ class IASakStatusProdusent(
 ) : KafkaProdusent<IASak>(kafka, topic),
     Observer<IASak> {
     override fun receive(input: IASak) {
-        // TODO: Hva gjør denne observeren, hvorfor sender den saken den mottar og sender siste aktive sak på orgnr?
         sendPåKafka(input = input)
 
         if (input.status == IAProsessStatus.SLETTET) {

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/KafkaProdusent.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/KafkaProdusent.kt
@@ -8,9 +8,9 @@ import org.apache.kafka.clients.producer.ProducerRecord
 abstract class KafkaProdusent<T>(
     protected val kafka: Kafka,
     protected val topic: Topic,
+    protected val clientId: String = topic.konsumentGruppe,
 ) {
-    private val produsent: KafkaProducer<String, String> =
-        KafkaProducer(kafka.producerProperties(clientId = topic.konsumentGruppe))
+    private val produsent: KafkaProducer<String, String> = KafkaProducer(kafka.producerProperties(clientId = clientId))
 
     init {
         Runtime.getRuntime().addShutdownHook(

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/SamarbeidBigqueryEksporterer.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/SamarbeidBigqueryEksporterer.kt
@@ -23,9 +23,7 @@ class SamarbeidBigqueryEksporterer(
         log.info("Starter re-eksport av ${alleSamarbeid.size} samarbeid")
 
         try {
-            alleSamarbeid.forEach { nåværendeSamarbeid ->
-                samarbeidBigqueryProdusent.reEksporter(nåværendeSamarbeid)
-            }
+            alleSamarbeid.forEach { nåværendeSamarbeid -> samarbeidBigqueryProdusent.receive(nåværendeSamarbeid) }
         } catch (e: Exception) {
             KJØRER_STATISTIKK_EKSPORT.set(false)
             log.error("Klarte ikke å kjøre eksport av samarbeid", e)

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/SamarbeidProdusent.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/SamarbeidProdusent.kt
@@ -9,7 +9,8 @@ import no.nav.lydia.ia.sak.db.ProsessRepository.SamarbeidIVirksomhetDto
 class SamarbeidProdusent(
     kafka: Kafka,
     topic: Topic = Topic.SAMARBEIDSPLAN_TOPIC,
-) : KafkaProdusent<SamarbeidIVirksomhetDto>(kafka, topic) {
+    clientId: String = "${topic.konsumentGruppe}-samarbeid-producer",
+) : KafkaProdusent<SamarbeidIVirksomhetDto>(kafka = kafka, topic = topic, clientId = clientId) {
     override fun tilKafkaMelding(input: SamarbeidIVirksomhetDto): Pair<String, String> {
         val nøkkel = "${input.saksnummer}-${input.samarbeid.id}"
         val verdi = SamarbeidKafkaMeldingValue(

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/SamarbeidsplanBigqueryEksporterer.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/SamarbeidsplanBigqueryEksporterer.kt
@@ -23,9 +23,7 @@ class SamarbeidsplanBigqueryEksporterer(
         log.info("Starter re-eksport av ${allePlaner.size} samarbeidsplaner")
 
         try {
-            allePlaner.forEach { nåværendePlan ->
-                samarbeidsplanBigqueryProdusent.reEksporter(nåværendePlan)
-            }
+            allePlaner.forEach { nåværendePlan -> samarbeidsplanBigqueryProdusent.reEksporter(plan = nåværendePlan) }
         } catch (e: Exception) {
             KJØRER_STATISTIKK_EKSPORT.set(false)
             log.error("Klarte ikke å kjøre eksport av samarbeidsplaner", e)

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/SamarbeidsplanProdusent.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/SamarbeidsplanProdusent.kt
@@ -14,7 +14,8 @@ import no.nav.lydia.ia.sak.domene.prosess.IAProsessStatus
 class SamarbeidsplanProdusent(
     kafka: Kafka,
     topic: Topic = Topic.SAMARBEIDSPLAN_TOPIC,
-) : KafkaProdusent<SamarbeidsplanKafkaMelding>(kafka, topic) {
+    clientId: String = "${topic.konsumentGruppe}-samarbeidsplan-producer",
+) : KafkaProdusent<SamarbeidsplanKafkaMelding>(kafka = kafka, topic = topic, clientId = clientId) {
     // TODO: burde ikke denne ta i mot domene og gjøre om til KAFKA melding?
     override fun tilKafkaMelding(input: SamarbeidsplanKafkaMelding): Pair<String, String> {
         val key = "${input.saksnummer}-${input.samarbeid.id}-${input.plan.id}"

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/SpørreundersøkelseBigqueryEksporterer.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/SpørreundersøkelseBigqueryEksporterer.kt
@@ -24,7 +24,7 @@ class SpørreundersøkelseBigqueryEksporterer(
 
         try {
             alleSpørreundersøkelser.forEach { gjeldendeSpørreundersøkelse ->
-                spørreundersøkelseBigqueryProdusent.reEksporter(gjeldendeSpørreundersøkelse)
+                spørreundersøkelseBigqueryProdusent.receive(gjeldendeSpørreundersøkelse)
             }
         } catch (e: Exception) {
             KJØRER_STATISTIKK_EKSPORT.set(false)

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/SpørreundersøkelseOppdateringProdusent.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/SpørreundersøkelseOppdateringProdusent.kt
@@ -26,6 +26,7 @@ class SpørreundersøkelseOppdateringProdusent(
     }
 
     // TODO: Se på å implementere KafkaProdusent<T> for å unngå duplisering av kode
+    // Evt bare dropp det helt når pia-survey gjør det obsolete
     fun <T> sendPåKafka(oppdatering: SpørreundersøkelseOppdatering<T>) {
         val (nøkkel, verdi) = oppdatering.tilKafkaMelding()
         produsent.send(

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/SpørreundersøkelseProdusent.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/SpørreundersøkelseProdusent.kt
@@ -9,8 +9,8 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toKotlinLocalDateTime
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import no.nav.lydia.Kafka
 import no.nav.lydia.Observer
 import no.nav.lydia.Topic
 import no.nav.lydia.ia.sak.api.plan.PlanDto
@@ -23,75 +23,63 @@ import no.nav.lydia.ia.sak.domene.spørreundersøkelse.Svaralternativ
 import no.nav.lydia.ia.sak.domene.spørreundersøkelse.Tema
 
 class SpørreundersøkelseProdusent(
-    private val produsent: KafkaProdusent,
+    kafka: Kafka,
+    topic: Topic = Topic.SPORREUNDERSOKELSE_TOPIC,
     private val iaProsessRepository: ProsessRepository,
     private val planRepository: PlanRepository,
-) : Observer<Spørreundersøkelse> {
-    override fun receive(input: Spørreundersøkelse) {
-        sendPåKafka(spørreundersøkelse = input)
-    }
+) : KafkaProdusent<Spørreundersøkelse>(kafka, topic),
+    Observer<Spørreundersøkelse> {
+    override fun receive(input: Spørreundersøkelse) = sendPåKafka(input = input)
 
-    fun sendPåKafka(spørreundersøkelse: Spørreundersøkelse) {
+    override fun tilKafkaMelding(input: Spørreundersøkelse): Pair<String, String> {
         val samarbeidNavn = iaProsessRepository.hentProsess(
-            saksnummer = spørreundersøkelse.saksnummer,
-            prosessId = spørreundersøkelse.samarbeidId,
-        )?.navn ?: spørreundersøkelse.virksomhetsNavn
-        val plan = when (spørreundersøkelse.type) {
-            "Evaluering" -> planRepository.hentPlan(spørreundersøkelse.samarbeidId)
+            saksnummer = input.saksnummer,
+            prosessId = input.samarbeidId,
+        )?.navn ?: input.virksomhetsNavn
+
+        val plan = when (input.type) {
+            "Evaluering" -> planRepository.hentPlan(input.samarbeidId)?.tilDto()
             else -> null
         }
-        val (nøkkel, verdi) = spørreundersøkelse.tilKafkaMelding(samarbeidNavn, plan?.tilDto())
-        produsent.sendMelding(
-            topic = Topic.SPORREUNDERSOKELSE_TOPIC.navn,
-            nøkkel = nøkkel,
-            verdi = verdi,
+
+        val nøkkel = input.id.toString()
+        val verdi = SerializableSpørreundersøkelse(
+            id = input.id.toString(),
+            orgnummer = input.orgnummer,
+            virksomhetsNavn = input.virksomhetsNavn,
+            samarbeidsNavn = samarbeidNavn,
+            status = input.status,
+            type = input.type,
+            plan = plan,
+            temaer = input.temaer.map { it.tilKafkaMelding() },
+            opprettet = input.opprettetTidspunkt,
+            endret = input.endretTidspunkt,
+            gyldigTil = input.opprettetTidspunkt.toJavaLocalDateTime().plusDays(1).toKotlinLocalDateTime(),
         )
+        return nøkkel to Json.encodeToString(verdi)
     }
 
-    companion object {
-        fun Spørreundersøkelse.tilKafkaMelding(
-            samarbeidsnavn: String,
-            plan: PlanDto?,
-        ): Pair<String, String> {
-            val nøkkel = this.id.toString()
-            val verdi = SerializableSpørreundersøkelse(
-                id = this.id.toString(),
-                orgnummer = orgnummer,
-                virksomhetsNavn = virksomhetsNavn,
-                samarbeidsNavn = samarbeidsnavn,
-                status = this.status,
-                type = this.type,
-                plan = plan,
-                temaer = temaer.map { it.tilKafkaMelding() },
-                opprettet = opprettetTidspunkt,
-                endret = endretTidspunkt,
-                gyldigTil = opprettetTidspunkt.toJavaLocalDateTime().plusDays(1).toKotlinLocalDateTime(),
-            )
-            return nøkkel to Json.encodeToString(verdi)
-        }
+    private fun Tema.tilKafkaMelding() =
+        SerializableTema(
+            id = this.tema.id,
+            navn = this.tema.navn,
+            spørsmål = this.spørsmål.map { it.tilKafkaMelding() },
+        )
 
-        private fun Tema.tilKafkaMelding() =
-            SerializableTema(
-                id = this.tema.id,
-                navn = this.tema.navn,
-                spørsmål = this.spørsmål.map { it.tilKafkaMelding() },
-            )
+    private fun Spørsmål.tilKafkaMelding() =
+        SerializableSpørsmål(
+            id = spørsmålId.toString(),
+            tekst = spørsmåltekst,
+            svaralternativer = svaralternativer.map { it.tilKafkaMelding() },
+            flervalg = flervalg,
+            kategori = undertemanavn,
+        )
 
-        private fun Spørsmål.tilKafkaMelding() =
-            SerializableSpørsmål(
-                id = spørsmålId.toString(),
-                tekst = spørsmåltekst,
-                svaralternativer = svaralternativer.map { it.tilKafkaMelding() },
-                flervalg = flervalg,
-                kategori = undertemanavn,
-            )
-
-        private fun Svaralternativ.tilKafkaMelding() =
-            SerializableSvaralternativ(
-                id = svarId.toString(),
-                tekst = svartekst,
-            )
-    }
+    private fun Svaralternativ.tilKafkaMelding() =
+        SerializableSvaralternativ(
+            id = svarId.toString(),
+            tekst = svartekst,
+        )
 
     @Serializable
     data class SerializableSpørreundersøkelse(

--- a/src/main/kotlin/no/nav/lydia/ia/sak/db/ProsessRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/db/ProsessRepository.kt
@@ -7,7 +7,6 @@ import kotliquery.queryOf
 import kotliquery.sessionOf
 import kotliquery.using
 import no.nav.lydia.ia.eksport.SamarbeidDto
-import no.nav.lydia.ia.eksport.SamarbeidIVirksomhetDto
 import no.nav.lydia.ia.sak.DEFAULT_SAMARBEID_NAVN
 import no.nav.lydia.ia.sak.api.prosess.IAProsessDto
 import no.nav.lydia.ia.sak.domene.ProsessHendelse
@@ -192,4 +191,10 @@ class ProsessRepository(
                 endretTidspunkt = row.localDateTimeOrNull("endret_tidspunkt")?.toKotlinLocalDateTime(),
             ),
         )
+
+    data class SamarbeidIVirksomhetDto(
+        val orgnr: String,
+        val saksnummer: String,
+        val samarbeid: SamarbeidDto,
+    )
 }

--- a/src/main/kotlin/no/nav/lydia/vedlikehold/LukkAlleÅpneIaTjenester.kt
+++ b/src/main/kotlin/no/nav/lydia/vedlikehold/LukkAlleÅpneIaTjenester.kt
@@ -2,12 +2,15 @@ package no.nav.lydia.vedlikehold
 
 import kotlinx.datetime.toKotlinLocalDate
 import kotlinx.datetime.toKotlinLocalDateTime
+import kotlinx.serialization.json.Json
 import no.nav.lydia.ia.eksport.IASakLeveranseProdusent
+import no.nav.lydia.ia.eksport.IASakLeveranseProdusent.IASakLeveranseValue
 import no.nav.lydia.ia.sak.api.IASakLeveranseOppdateringsDto
 import no.nav.lydia.ia.sak.db.IASakLeveranseRepository
 import no.nav.lydia.ia.sak.domene.IASakLeveranseStatus
 import no.nav.lydia.tilgangskontroll.fia.NavAnsatt
 import no.nav.lydia.tilgangskontroll.fia.Rolle
+import java.time.LocalDateTime
 
 class LukkAlleÅpneIaTjenester(
     val iaSakLeveranseRepository: IASakLeveranseRepository,
@@ -27,27 +30,27 @@ class LukkAlleÅpneIaTjenester(
                     emptySet(),
                 ),
             ).map { iaTjeneste ->
-                iaSakLeveranseProdusent.sendMelding(
-                    iaTjeneste.id.toString(),
-                    IASakLeveranseProdusent.IASakLeveranseValue(
-                        iaTjeneste.id,
-                        iaTjeneste.saksnummer,
-                        iaTjeneste.modul.iaTjeneste.id,
-                        iaTjeneste.modul.iaTjeneste.navn,
-                        iaTjeneste.modul.id,
-                        iaTjeneste.modul.navn,
-                        iaTjeneste.frist.toKotlinLocalDate(),
-                        IASakLeveranseStatus.LEVERT,
-                        iaTjeneste.opprettetAv,
-                        java.time.LocalDateTime.now().toKotlinLocalDateTime(),
-                        "Fia system",
-                        Rolle.SUPERBRUKER,
-                        java.time.LocalDateTime.now().toKotlinLocalDateTime(),
-                        IASakStatusOppdaterer.NAV_ENHET_FOR_TILBAKEFØRING.enhetsnummer,
-                        IASakStatusOppdaterer.NAV_ENHET_FOR_TILBAKEFØRING.enhetsnavn,
-                        iaTjeneste.opprettetTidspunkt?.toKotlinLocalDateTime(),
-                    ),
+                val nøkkel = iaTjeneste.id.toString()
+                val verdi = IASakLeveranseValue(
+                    id = iaTjeneste.id,
+                    saksnummer = iaTjeneste.saksnummer,
+                    iaTjenesteId = iaTjeneste.modul.iaTjeneste.id,
+                    iaTjenesteNavn = iaTjeneste.modul.iaTjeneste.navn,
+                    iaModulId = iaTjeneste.modul.id,
+                    iaModulNavn = iaTjeneste.modul.navn,
+                    frist = iaTjeneste.frist.toKotlinLocalDate(),
+                    status = IASakLeveranseStatus.LEVERT,
+                    opprettetAv = iaTjeneste.opprettetAv,
+                    sistEndret = LocalDateTime.now().toKotlinLocalDateTime(),
+                    sistEndretAv = "Fia system",
+                    sistEndretAvRolle = Rolle.SUPERBRUKER,
+                    fullført = LocalDateTime.now().toKotlinLocalDateTime(),
+                    enhetsnummer = IASakStatusOppdaterer.NAV_ENHET_FOR_TILBAKEFØRING.enhetsnummer,
+                    enhetsnavn = IASakStatusOppdaterer.NAV_ENHET_FOR_TILBAKEFØRING.enhetsnavn,
+                    opprettetTidspunkt = iaTjeneste.opprettetTidspunkt?.toKotlinLocalDateTime(),
                 )
+
+                iaSakLeveranseProdusent.sendMelding(nøkkel, Json.encodeToString(verdi))
             }
         }
     }

--- a/src/test/kotlin/no/nav/lydia/container/ia/eksport/FullførtBehovsvurderingProdusentTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/eksport/FullførtBehovsvurderingProdusentTest.kt
@@ -13,7 +13,7 @@ import no.nav.lydia.helper.IASakKartleggingHelper.Companion.start
 import no.nav.lydia.helper.SakHelper.Companion.nySakIKartleggesMedEtSamarbeid
 import no.nav.lydia.helper.TestContainerHelper.Companion.kafkaContainerHelper
 import no.nav.lydia.helper.forExactlyOne
-import no.nav.lydia.ia.eksport.FullførtBehovsvurdering
+import no.nav.lydia.ia.eksport.FullførtBehovsvurderingProdusent.FullførtBehovsvurdering
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import kotlin.test.Test

--- a/src/test/kotlin/no/nav/lydia/container/ia/eksport/SamarbeidEksportererTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/eksport/SamarbeidEksportererTest.kt
@@ -17,7 +17,7 @@ import no.nav.lydia.helper.TestContainerHelper.Companion.shouldContainLog
 import no.nav.lydia.helper.forExactlyOne
 import no.nav.lydia.helper.hentAlleSamarbeid
 import no.nav.lydia.ia.eksport.SAMARBEID_ID_PREFIKS
-import no.nav.lydia.ia.eksport.SamarbeidKafkaMeldingValue
+import no.nav.lydia.ia.eksport.SamarbeidProdusent.SamarbeidKafkaMeldingValue
 import no.nav.lydia.ia.sak.DEFAULT_SAMARBEID_NAVN
 import org.junit.AfterClass
 import org.junit.BeforeClass

--- a/src/test/kotlin/no/nav/lydia/container/ia/eksport/SamarbeidProdusentTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/eksport/SamarbeidProdusentTest.kt
@@ -9,7 +9,7 @@ import no.nav.lydia.helper.SakHelper.Companion.nySakIKartleggesMedEtSamarbeid
 import no.nav.lydia.helper.TestContainerHelper.Companion.kafkaContainerHelper
 import no.nav.lydia.helper.forExactlyOne
 import no.nav.lydia.helper.hentAlleSamarbeid
-import no.nav.lydia.ia.eksport.SamarbeidKafkaMeldingValue
+import no.nav.lydia.ia.eksport.SamarbeidProdusent.SamarbeidKafkaMeldingValue
 import no.nav.lydia.ia.sak.DEFAULT_SAMARBEID_NAVN
 import no.nav.lydia.ia.sak.api.IASakDto
 import no.nav.lydia.ia.sak.api.prosess.IAProsessDto

--- a/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/BehovsvurderingApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/BehovsvurderingApiTest.kt
@@ -42,7 +42,7 @@ import no.nav.lydia.helper.forExactlyOne
 import no.nav.lydia.helper.hentAlleSamarbeid
 import no.nav.lydia.helper.opprettNyttSamarbeid
 import no.nav.lydia.helper.tilSingelRespons
-import no.nav.lydia.ia.eksport.FullførtBehovsvurdering
+import no.nav.lydia.ia.eksport.FullførtBehovsvurderingProdusent.FullførtBehovsvurdering
 import no.nav.lydia.ia.eksport.SpørreundersøkelseProdusent.SerializableSpørreundersøkelse
 import no.nav.lydia.ia.sak.api.spørreundersøkelse.SPØRREUNDERSØKELSE_BASE_ROUTE
 import no.nav.lydia.ia.sak.api.spørreundersøkelse.SpørreundersøkelseDto

--- a/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/SpørreundersøkelseHendelseKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/SpørreundersøkelseHendelseKonsumentTest.kt
@@ -4,7 +4,6 @@ import ia.felles.integrasjoner.kafkameldinger.spørreundersøkelse.Spørreunders
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import no.nav.lydia.Topic
 import no.nav.lydia.helper.IASakKartleggingHelper
@@ -131,7 +130,7 @@ class SpørreundersøkelseHendelseKonsumentTest {
 
         spørreundersøkelse.stengTema(temaId = tema.temaId)
         runBlocking {
-            TestContainerHelper.kafkaContainerHelper.ventOgKonsumerKafkaMeldinger(
+            kafkaContainerHelper.ventOgKonsumerKafkaMeldinger(
                 key = Json.encodeToString(
                     SpørreundersøkelseOppdateringNøkkel(
                         spørreundersøkelseId = spørreundersøkelse.id,

--- a/src/test/kotlin/no/nav/lydia/container/ia/sak/prosess/IASakProsessTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/sak/prosess/IASakProsessTest.kt
@@ -9,7 +9,6 @@ import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import no.nav.lydia.Topic
 import no.nav.lydia.helper.IASakKartleggingHelper.Companion.opprettSpørreundersøkelse

--- a/src/test/kotlin/no/nav/lydia/helper/KafkaContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/KafkaContainerHelper.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.time.withTimeout
 import kotlinx.coroutines.time.withTimeoutOrNull
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import no.nav.lydia.Kafka
 import no.nav.lydia.Topic

--- a/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
@@ -20,7 +20,6 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toKotlinLocalDate
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import no.nav.lydia.Topic


### PR DESCRIPTION
Konfigurerer alle kafkaprodusenter på nytt, dette gjør vi for å få unik id (per gruppe).

- Kafka config tar inn clientId som kan settes per topic (groupID eller tidligere consumerGroupId)
- Alle topics får en groupId (i stedet for at bare topics vi konsumerer fra eller konsumerer fra i tester har det)
- Produsentene arver fra generisk KafkaProdusent klasse for å redusere duplisert kode.