### PR TITLE
Bytter namespace fra 'arbeidsgiver' til 'pia' 

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/drop_columns_endret_av_i_ia_prosess'
+    if: github.ref == 'refs/heads/nytt-namespace-for-statistikk-topics'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
+++ b/src/main/kotlin/no/nav/lydia/NaisEnvironment.kt
@@ -206,35 +206,35 @@ enum class Topic(
         konsumentGruppe = "lydia-api-brreg-alle-virksomheter-consumer",
     ),
     STATISTIKK_METADATA_VIRKSOMHET_TOPIC(
-        navn = "arbeidsgiver.sykefravarsstatistikk-metadata-virksomhet-v1",
+        navn = "pia.sykefravarsstatistikk-metadata-virksomhet-v1",
         konsumentGruppe = "lydia-api-statistikk-metadata-virksomhet-consumer",
     ),
     STATISTIKK_LAND_TOPIC(
-        navn = "arbeidsgiver.sykefravarsstatistikk-land-v1",
+        navn = "pia.sykefravarsstatistikk-land-v1",
         konsumentGruppe = "lydia-api-statistikk-land-consumer",
     ),
     STATISTIKK_SEKTOR_TOPIC(
-        navn = "arbeidsgiver.sykefravarsstatistikk-sektor-v1",
+        navn = "pia.sykefravarsstatistikk-sektor-v1",
         konsumentGruppe = "lydia-api-statistikk-sektor-consumer",
     ),
     STATISTIKK_BRANSJE_TOPIC(
-        navn = "arbeidsgiver.sykefravarsstatistikk-bransje-v1",
+        navn = "pia.sykefravarsstatistikk-bransje-v1",
         konsumentGruppe = "lydia-api-statistikk-bransje-consumer",
     ),
     STATISTIKK_NARING_TOPIC(
-        navn = "arbeidsgiver.sykefravarsstatistikk-naring-v1",
+        navn = "pia.sykefravarsstatistikk-naring-v1",
         konsumentGruppe = "lydia-api-statistikk-naring-consumer",
     ),
     STATISTIKK_NARINGSKODE_TOPIC(
-        navn = "arbeidsgiver.sykefravarsstatistikk-naringskode-v1",
+        navn = "pia.sykefravarsstatistikk-naringskode-v1",
         konsumentGruppe = "lydia-api-statistikk-naringskode-consumer",
     ),
     STATISTIKK_VIRKSOMHET_TOPIC(
-        navn = "arbeidsgiver.sykefravarsstatistikk-virksomhet-v1",
+        navn = "pia.sykefravarsstatistikk-virksomhet-v1",
         konsumentGruppe = "lydia-api-statistikk-virksomhet-consumer",
     ),
     STATISTIKK_VIRKSOMHET_GRADERING_TOPIC(
-        navn = "arbeidsgiver.sykefravarsstatistikk-virksomhet-gradert-v1",
+        navn = "pia.sykefravarsstatistikk-virksomhet-gradert-v1",
         konsumentGruppe = "lydia-api-statistikk-virksomhet-gradering-consumer",
     ),
     JOBBLYTTER_TOPIC(

--- a/src/test/kotlin/no/nav/lydia/container/sykefraværsstatistikk/importering/SykefraværsstatistikkVirksomhetImportTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraværsstatistikk/importering/SykefraværsstatistikkVirksomhetImportTest.kt
@@ -241,7 +241,7 @@ class SykefraværsstatistikkVirksomhetImportTest {
         )
 
         applikasjon shouldContainLog
-            "Lagret 1 meldinger i StatistikkVirksomhetGraderingConsumer \\(topic 'arbeidsgiver.sykefravarsstatistikk-virksomhet-gradert-v1'\\)"
+            "Lagret 1 meldinger i StatistikkVirksomhetGraderingConsumer \\(topic 'pia.sykefravarsstatistikk-virksomhet-gradert-v1'\\)"
                 .toRegex()
 
         val resultat = hentStatistikkVirksomhetGraderingGjeldendeKvartal(orgnr = "999999999", kvartal = KVARTAL_2023_1)


### PR DESCRIPTION
Bytter namespace fra 'arbeidsgiver' til 'pia' for alle sykefravarsstatistikk-* topics da disse får data fra pia-sykefraværsstatistikk (og ikke lenger fra den gamle sykefraværsstatistikk-api)

OBS: ikke deploy i PROD før eksport i `pia-sykefraværsstatistikk` er ferdig