### PR TITLE
Bytte Kanal for journalføring

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/dokument-publisering'
+    if: github.ref == 'refs/heads/ny-kanal-for-utsending-av-dok'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/src/main/kotlin/no/nav/lydia/integrasjoner/journalpost/JournalpostDto.kt
+++ b/src/main/kotlin/no/nav/lydia/integrasjoner/journalpost/JournalpostDto.kt
@@ -25,7 +25,8 @@ enum class Variantformat {
 }
 
 enum class Kanal {
-    NAV_NO,
+    NAV_NO, // <-- ikke bruk
+    NAV_NO_UTEN_VARSLING,
 }
 
 enum class JournalpostTema {

--- a/src/main/kotlin/no/nav/lydia/integrasjoner/journalpost/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/lydia/integrasjoner/journalpost/JournalpostService.kt
@@ -76,7 +76,7 @@ class JournalpostService(
             tema = JournalpostTema.IAR,
             journalposttype = JournalpostType.UTGAAENDE,
             journalfoerendeEnhet = sakshendelse.navEnhet.enhetsnummer,
-            kanal = Kanal.NAV_NO,
+            kanal = Kanal.NAV_NO_UTEN_VARSLING,
             avsenderMottaker = AvsenderMottaker(
                 id = sakshendelse.orgnummer,
                 idType = IdType.ORGNR,


### PR DESCRIPTION
Ønske fra team dokumentløsninger om å bytte utsendingskanal fra `NAV_NO` til `NAV_NO_UTEN_VARSLING` da sistnevnte gir mindre rom for misforståelser i fagsystemet for arkiv. 