### PR TITLE
Fjern sist_publisert fra ia_sak_plan

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/opprydding'
+    if: github.ref == 'refs/heads/fjern-sist-publisert'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/src/main/kotlin/no/nav/lydia/ia/eksport/SamarbeidsplanProdusent.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/eksport/SamarbeidsplanProdusent.kt
@@ -63,7 +63,7 @@ fun PlanDto.tilPlanKafkaMeldingDto() =
     PlanKafkaMeldingDto(
         id = this.id,
         sistEndret = this.sistEndret,
-        sistPublisert = this.sistPublisert,
+        sistPublisert = this.sistPublisert?.date,
         status = this.status,
         temaer = this.temaer.tilPlanTemaKafkaMeldingDtoer(),
     )

--- a/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/NyFlytSamarbeidsplanRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/NyFlytSamarbeidsplanRoutes.kt
@@ -35,7 +35,7 @@ import no.nav.lydia.ia.sak.api.ny.flyt.tilstandsmaskin.hendelse.OpprettPlanForSa
 import no.nav.lydia.ia.sak.api.ny.flyt.tilstandsmaskin.hendelse.SlettPlanForSamarbeid
 import no.nav.lydia.ia.sak.api.plan.EndreTemaRequest
 import no.nav.lydia.ia.sak.api.plan.EndreUndertemaRequest
-import no.nav.lydia.ia.sak.api.plan.PlanMedPubliseringStatusDto
+import no.nav.lydia.ia.sak.api.plan.PlanDto
 import no.nav.lydia.ia.sak.api.plan.tilDtoMedPubliseringStatus
 import no.nav.lydia.ia.sak.domene.plan.Plan
 import no.nav.lydia.ia.sak.domene.plan.PlanMalDto
@@ -123,8 +123,8 @@ fun Route.nyFlytSamarbeidsplan(
                     samarbeidId = samarbeidId,
                 ),
             )
-            konsekvens.endring.map { (it as PlanMedPubliseringStatusDto) }
-        }.also { planMedPlubliseringStatusDtoEither: Either<Feil, PlanMedPubliseringStatusDto> ->
+            konsekvens.endring.map { (it as PlanDto) }
+        }.also { planMedPlubliseringStatusDtoEither: Either<Feil, PlanDto> ->
             auditLog.auditloggEither(
                 call = call,
                 either = planMedPlubliseringStatusDtoEither,
@@ -132,8 +132,8 @@ fun Route.nyFlytSamarbeidsplan(
                 auditType = AuditType.update,
                 saksnummer = saksnummerUrlParameter,
             )
-        }.map { planMedPubliseringStatusDto: PlanMedPubliseringStatusDto ->
-            call.respond(status = HttpStatusCode.OK, message = planMedPubliseringStatusDto)
+        }.map { planDto: PlanDto ->
+            call.respond(status = HttpStatusCode.OK, message = planDto)
         }.mapLeft { feil: Feil ->
             call.respond(status = feil.httpStatusCode, message = feil.feilmelding)
         }
@@ -163,8 +163,8 @@ fun Route.nyFlytSamarbeidsplan(
                     navEnhet = navEnhet,
                 ),
             )
-            konsekvens.endring.map { (it as PlanMedPubliseringStatusDto) }
-        }.also { planMedPlubliseringStatusDtoEither: Either<Feil, PlanMedPubliseringStatusDto> ->
+            konsekvens.endring.map { (it as PlanDto) }
+        }.also { planMedPlubliseringStatusDtoEither: Either<Feil, PlanDto> ->
             auditLog.auditloggEither(
                 call = call,
                 either = planMedPlubliseringStatusDtoEither,
@@ -172,8 +172,8 @@ fun Route.nyFlytSamarbeidsplan(
                 auditType = AuditType.update,
                 saksnummer = saksnummerUrlParameter,
             )
-        }.map { planMedPubliseringStatusDto: PlanMedPubliseringStatusDto ->
-            call.respond(status = HttpStatusCode.OK, message = planMedPubliseringStatusDto)
+        }.map { planDto: PlanDto ->
+            call.respond(status = HttpStatusCode.OK, message = planDto)
         }.mapLeft { feil: Feil ->
             call.respond(status = feil.httpStatusCode, message = feil.feilmelding)
         }
@@ -210,8 +210,8 @@ fun Route.nyFlytSamarbeidsplan(
                     navEnhet = navEnhet,
                 ),
             )
-            konsekvens.endring.map { (it as PlanMedPubliseringStatusDto) }
-        }.also { planMedPlubliseringStatusDtoEither: Either<Feil, PlanMedPubliseringStatusDto> ->
+            konsekvens.endring.map { (it as PlanDto) }
+        }.also { planMedPlubliseringStatusDtoEither: Either<Feil, PlanDto> ->
             auditLog.auditloggEither(
                 call = call,
                 either = planMedPlubliseringStatusDtoEither,
@@ -219,8 +219,8 @@ fun Route.nyFlytSamarbeidsplan(
                 auditType = AuditType.update,
                 saksnummer = saksnummerUrlParameter,
             )
-        }.map { planMedPubliseringStatusDto: PlanMedPubliseringStatusDto ->
-            call.respond(status = HttpStatusCode.OK, message = planMedPubliseringStatusDto)
+        }.map { planDto: PlanDto ->
+            call.respond(status = HttpStatusCode.OK, message = planDto)
         }.mapLeft { feil: Feil ->
             call.respond(status = feil.httpStatusCode, message = feil.feilmelding)
         }
@@ -266,8 +266,8 @@ fun Route.nyFlytSamarbeidsplan(
                     navEnhet = navEnhet,
                 ),
             )
-            konsekvens.endring.map { (it as PlanMedPubliseringStatusDto) }
-        }.also { planMedPlubliseringStatusDtoEither: Either<Feil, PlanMedPubliseringStatusDto> ->
+            konsekvens.endring.map { (it as PlanDto) }
+        }.also { planMedPlubliseringStatusDtoEither: Either<Feil, PlanDto> ->
             auditLog.auditloggEither(
                 call = call,
                 either = planMedPlubliseringStatusDtoEither,
@@ -275,8 +275,8 @@ fun Route.nyFlytSamarbeidsplan(
                 auditType = AuditType.update,
                 saksnummer = saksnummerUrlParameter,
             )
-        }.map { planMedPubliseringStatusDto: PlanMedPubliseringStatusDto ->
-            call.respond(status = HttpStatusCode.OK, message = planMedPubliseringStatusDto)
+        }.map { planDto: PlanDto ->
+            call.respond(status = HttpStatusCode.OK, message = planDto)
         }.mapLeft { feil: Feil ->
             call.respond(status = feil.httpStatusCode, message = feil.feilmelding)
         }
@@ -302,7 +302,7 @@ fun Route.nyFlytSamarbeidsplan(
                 ),
             )
             konsekvens.endring.map { (it as Plan).tilDtoMedPubliseringStatus() }
-        }.also { planMedPlubliseringStatusDtoEither: Either<Feil, PlanMedPubliseringStatusDto> ->
+        }.also { planMedPlubliseringStatusDtoEither: Either<Feil, PlanDto> ->
             auditLog.auditloggEither(
                 call = call,
                 either = planMedPlubliseringStatusDtoEither,
@@ -310,8 +310,8 @@ fun Route.nyFlytSamarbeidsplan(
                 auditType = AuditType.delete,
                 saksnummer = saksnummerUrlParameter,
             )
-        }.map { planMedPubliseringStatusDto: PlanMedPubliseringStatusDto ->
-            call.respond(status = HttpStatusCode.OK, message = planMedPubliseringStatusDto)
+        }.map { planDto: PlanDto ->
+            call.respond(status = HttpStatusCode.OK, message = planDto)
         }.mapLeft { feil: Feil ->
             call.respond(status = feil.httpStatusCode, message = feil.feilmelding)
         }

--- a/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/Transaction.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/Transaction.kt
@@ -930,7 +930,6 @@ private fun tilPlan(
         id = planIdLestFraDB,
         samarbeidId = row.int("ia_prosess"),
         sistEndret = row.localDateTime("sist_endret").toKotlinLocalDateTime(),
-        sistPublisert = row.localDateOrNull("sist_publisert")?.toKotlinLocalDate(),
         status = IASamarbeid.Status.valueOf(row.string("status")),
         temaer = hentTema(planIdLestFraDB, tx = tx),
     )

--- a/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/tilstandsmaskin/sideeffect/EndreStatusPåUndertemaISamarbeidsplanSideEffect.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/tilstandsmaskin/sideeffect/EndreStatusPåUndertemaISamarbeidsplanSideEffect.kt
@@ -6,7 +6,7 @@ import no.nav.lydia.ia.sak.api.Feil
 import no.nav.lydia.ia.sak.api.ny.flyt.NyFlytService
 import no.nav.lydia.ia.sak.api.ny.flyt.Transaction
 import no.nav.lydia.ia.sak.api.ny.flyt.endreStatusPåUndertemaISamarbeidsplan
-import no.nav.lydia.ia.sak.api.plan.PlanMedPubliseringStatusDto
+import no.nav.lydia.ia.sak.api.plan.PlanDto
 import no.nav.lydia.ia.sak.api.plan.tilDtoMedPubliseringStatus
 import no.nav.lydia.ia.sak.domene.plan.Plan
 import no.nav.lydia.ia.sak.domene.plan.PlanUndertema
@@ -20,9 +20,9 @@ class EndreStatusPåUndertemaISamarbeidsplanSideEffect(
     val temaId: Int,
     val undertemaId: Int,
     val nyStatus: PlanUndertema.Status,
-) : SideEffect<PlanMedPubliseringStatusDto>() {
+) : SideEffect<PlanDto>() {
     context(nyFlytService: NyFlytService)
-    override fun apply(): Either<Feil, PlanMedPubliseringStatusDto> =
+    override fun apply(): Either<Feil, PlanDto> =
         nyFlytService.validerEndringAvStatusPåUndertema(
             samarbeidId = samarbeidId,
             planId = planId,
@@ -39,12 +39,12 @@ class EndreStatusPåUndertemaISamarbeidsplanSideEffect(
                         nyStatus = nyStatus,
                     ) ?: error("Kunne ikke oppdatere status på undertema '$undertemaId' i plan '$planId' for samarbeid $samarbeidId i sak $saksnummer")
 
-                    val planMedPubliseringStatusDto: PlanMedPubliseringStatusDto =
+                    val planDto: PlanDto =
                         oppdatertPlan.tilDtoMedPubliseringStatus()
 
-                    Pair(oppdatertPlan, planMedPubliseringStatusDto)
+                    Pair(oppdatertPlan, planDto)
                 }
-            }.also { planOgDto: Pair<Plan, PlanMedPubliseringStatusDto> ->
+            }.also { planOgDto: Pair<Plan, PlanDto> ->
                 nyFlytService.planService.varslePlanObservers(planOgDto.first, PlanHendelseType.ENDRE_STATUS)
             }.second
         }

--- a/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/tilstandsmaskin/sideeffect/OppdaterPlanForSamarbeidSideEffect.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/tilstandsmaskin/sideeffect/OppdaterPlanForSamarbeidSideEffect.kt
@@ -7,7 +7,7 @@ import no.nav.lydia.ia.sak.api.ny.flyt.NyFlytService
 import no.nav.lydia.ia.sak.api.ny.flyt.Transaction
 import no.nav.lydia.ia.sak.api.ny.flyt.oppdaterSamarbeidsplan
 import no.nav.lydia.ia.sak.api.plan.EndreTemaRequest
-import no.nav.lydia.ia.sak.api.plan.PlanMedPubliseringStatusDto
+import no.nav.lydia.ia.sak.api.plan.PlanDto
 import no.nav.lydia.ia.sak.api.plan.tilDtoMedPubliseringStatus
 import no.nav.lydia.ia.sak.domene.plan.Plan
 import java.util.UUID
@@ -18,9 +18,9 @@ class OppdaterPlanForSamarbeidSideEffect(
     val samarbeidId: Int,
     val planId: UUID,
     val endringer: List<EndreTemaRequest>,
-) : SideEffect<PlanMedPubliseringStatusDto>() {
+) : SideEffect<PlanDto>() {
     context(nyFlytService: NyFlytService)
-    override fun apply(): Either<Feil, PlanMedPubliseringStatusDto> =
+    override fun apply(): Either<Feil, PlanDto> =
         nyFlytService.validerOppdateringAvSamarbeidsplan(
             samarbeidId = samarbeidId,
             planId = planId,
@@ -34,12 +34,12 @@ class OppdaterPlanForSamarbeidSideEffect(
                         endringer = endringer,
                     ) ?: error("Kunne ikke oppdatere samarbeidsplan med id '$planId' for samarbeid $samarbeidId i sak $saksnummer")
 
-                    val planMedPubliseringStatusDto: PlanMedPubliseringStatusDto =
+                    val planMedPubliseringStatusDto: PlanDto =
                         oppdatertSamarbeidsplan.tilDtoMedPubliseringStatus()
 
                     Pair(oppdatertSamarbeidsplan, planMedPubliseringStatusDto)
                 }
-            }.also { planOgIASak: Pair<Plan, PlanMedPubliseringStatusDto> ->
+            }.also { planOgIASak: Pair<Plan, PlanDto> ->
                 nyFlytService.planService.varslePlanObservers(planOgIASak.first, PlanHendelseType.OPPDATER)
             }.second
         }

--- a/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/tilstandsmaskin/sideeffect/OppdaterTemaIPlanForSamarbeidSideEffect.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/tilstandsmaskin/sideeffect/OppdaterTemaIPlanForSamarbeidSideEffect.kt
@@ -7,7 +7,7 @@ import no.nav.lydia.ia.sak.api.ny.flyt.NyFlytService
 import no.nav.lydia.ia.sak.api.ny.flyt.Transaction
 import no.nav.lydia.ia.sak.api.ny.flyt.oppdaterTemaISamarbeidsplan
 import no.nav.lydia.ia.sak.api.plan.EndreUndertemaRequest
-import no.nav.lydia.ia.sak.api.plan.PlanMedPubliseringStatusDto
+import no.nav.lydia.ia.sak.api.plan.PlanDto
 import no.nav.lydia.ia.sak.api.plan.tilDtoMedPubliseringStatus
 import no.nav.lydia.ia.sak.domene.plan.Plan
 import java.util.UUID
@@ -19,9 +19,9 @@ class OppdaterTemaIPlanForSamarbeidSideEffect(
     val planId: UUID,
     val temaId: Int,
     val endringer: List<EndreUndertemaRequest>,
-) : SideEffect<PlanMedPubliseringStatusDto>() {
+) : SideEffect<PlanDto>() {
     context(nyFlytService: NyFlytService)
-    override fun apply(): Either<Feil, PlanMedPubliseringStatusDto> =
+    override fun apply(): Either<Feil, PlanDto> =
         nyFlytService.validerOppdateringAvTemaISamarbeidsplan(
             samarbeidId = samarbeidId,
             planId = planId,
@@ -37,12 +37,12 @@ class OppdaterTemaIPlanForSamarbeidSideEffect(
                         endringer = endringer,
                     ) ?: error("Kunne ikke oppdatere tema med id '$temaId' i samarbeidsplan med id '$planId' for samarbeid $samarbeidId i sak $saksnummer")
 
-                    val planMedPubliseringStatusDto: PlanMedPubliseringStatusDto =
+                    val planMedPubliseringStatusDto: PlanDto =
                         oppdatertSamarbeidsplan.tilDtoMedPubliseringStatus()
 
                     Pair(oppdatertSamarbeidsplan, planMedPubliseringStatusDto)
                 }
-            }.also { planOgIASak: Pair<Plan, PlanMedPubliseringStatusDto> ->
+            }.also { planOgIASak: Pair<Plan, PlanDto> ->
                 nyFlytService.planService.varslePlanObservers(planOgIASak.first, PlanHendelseType.OPPDATER)
             }.second
         }

--- a/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/tilstandsmaskin/sideeffect/OpprettPlanForSamarbeidSideEffect.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/api/ny/flyt/tilstandsmaskin/sideeffect/OpprettPlanForSamarbeidSideEffect.kt
@@ -13,7 +13,7 @@ import no.nav.lydia.ia.sak.api.ny.flyt.lagreEllerOppdaterVirksomhetTilstand
 import no.nav.lydia.ia.sak.api.ny.flyt.lagreHendelse
 import no.nav.lydia.ia.sak.api.ny.flyt.oppdaterStatusPåSak
 import no.nav.lydia.ia.sak.api.ny.flyt.opprettSamarbeidsplan
-import no.nav.lydia.ia.sak.api.plan.PlanMedPubliseringStatusDto
+import no.nav.lydia.ia.sak.api.plan.PlanDto
 import no.nav.lydia.ia.sak.api.plan.tilDtoMedPubliseringStatus
 import no.nav.lydia.ia.sak.domene.IASakshendelse
 import no.nav.lydia.ia.sak.domene.IASakshendelseType
@@ -31,9 +31,9 @@ class OpprettPlanForSamarbeidSideEffect(
     val plan: PlanMalDto,
     val saksbehandler: NavAnsattMedSaksbehandlerRolle,
     val navEnhet: NavEnhet,
-) : SideEffect<PlanMedPubliseringStatusDto>() {
+) : SideEffect<PlanDto>() {
     context(nyFlytService: NyFlytService)
-    override fun apply(): Either<Feil, PlanMedPubliseringStatusDto> {
+    override fun apply(): Either<Feil, PlanDto> {
         val nyPlanId = UUID.randomUUID()
 
         return nyFlytService.validerOpprettelseAvSamarbeidsplan(
@@ -51,7 +51,7 @@ class OpprettPlanForSamarbeidSideEffect(
                         mal = planMalDto,
                     ) ?: error("Kunne ikke opprette samarbeidsplan for samarbeid $samarbeidId i sak $saksnummer")
 
-                    val planMedPubliseringStatusDto: PlanMedPubliseringStatusDto =
+                    val planDto: PlanDto =
                         opprettetSamarbeidsplan.tilDtoMedPubliseringStatus()
 
                     val opprettPlanHendelse = lagreHendelse(
@@ -80,9 +80,9 @@ class OpprettPlanForSamarbeidSideEffect(
                         orgnr = orgnummer,
                         tilstand = VirksomhetIATilstand.VirksomhetHarAktiveSamarbeid,
                     )
-                    Triple(opprettetSamarbeidsplan, planMedPubliseringStatusDto, oppdatertSakDto)
+                    Triple(opprettetSamarbeidsplan, planDto, oppdatertSakDto)
                 }
-            }.also { planOgIASak: Triple<Plan, PlanMedPubliseringStatusDto, IASakDto> ->
+            }.also { planOgIASak: Triple<Plan, PlanDto, IASakDto> ->
                 nyFlytService.varsleIASakObservers(sakDto = planOgIASak.third)
                 nyFlytService.planService.varslePlanObservers(planOgIASak.first, PlanHendelseType.OPPRETT)
             }.second

--- a/src/main/kotlin/no/nav/lydia/ia/sak/api/plan/PlanDto.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/api/plan/PlanDto.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.ia.sak.api.plan
 
-import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.serialization.Serializable
@@ -9,44 +8,27 @@ import no.nav.lydia.ia.sak.api.dokument.PubliseringStatus
 import no.nav.lydia.ia.sak.domene.plan.Plan
 import no.nav.lydia.ia.sak.domene.samarbeid.IASamarbeid
 
-interface PlanDtoI {
-    val id: String
-    val sistEndret: LocalDateTime
-    val status: IASamarbeid.Status
-    val temaer: List<PlanTemaDto>
-}
-
-@Serializable
-data class PlanDto(
-    override val id: String,
-    override val sistEndret: LocalDateTime,
-    val sistPublisert: LocalDate?,
-    override val status: IASamarbeid.Status,
-    override val temaer: List<PlanTemaDto>,
-) : PlanDtoI
-
 fun Plan.tilDto(): PlanDto =
     PlanDto(
         id = id.toString(),
         sistEndret = sistEndret,
-        sistPublisert = sistPublisert,
         status = status,
         temaer = temaer.tilDtoer(),
     )
 
 @Serializable
-data class PlanMedPubliseringStatusDto(
-    override val id: String,
-    override val sistEndret: LocalDateTime,
-    override val status: IASamarbeid.Status,
-    override val temaer: List<PlanTemaDto>,
+data class PlanDto(
+    val id: String,
+    val sistEndret: LocalDateTime,
+    val status: IASamarbeid.Status,
+    val temaer: List<PlanTemaDto>,
     val sistPublisert: LocalDateTime? = null,
     val publiseringStatus: DokumentPubliseringDto.Status? = null,
     val harEndringerSidenSistPublisert: Boolean = false,
-) : PlanDtoI
+)
 
-fun Plan.tilDtoMedPubliseringStatus(publiseringStatus: PubliseringStatus? = null): PlanMedPubliseringStatusDto =
-    PlanMedPubliseringStatusDto(
+fun Plan.tilDtoMedPubliseringStatus(publiseringStatus: PubliseringStatus? = null): PlanDto =
+    PlanDto(
         id = id.toString(),
         sistEndret = sistEndret,
         sistPublisert = publiseringStatus?.publiseringTidspunkt,
@@ -57,7 +39,10 @@ fun Plan.tilDtoMedPubliseringStatus(publiseringStatus: PubliseringStatus? = null
             DokumentPubliseringDto.Status.PUBLISERT -> {
                 sistEndret.erEtter(publiseringStatus.publiseringTidspunkt)
             }
-            else -> false
+
+            else -> {
+                false
+            }
         },
     )
 

--- a/src/main/kotlin/no/nav/lydia/ia/sak/db/PlanRepository.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/db/PlanRepository.kt
@@ -280,7 +280,6 @@ class PlanRepository(
             id = planIdLestFraDB,
             samarbeidId = row.int("ia_prosess"),
             sistEndret = row.localDateTime("sist_endret").toKotlinLocalDateTime(),
-            sistPublisert = row.localDateOrNull("sist_publisert")?.toKotlinLocalDate(),
             status = IASamarbeid.Status.valueOf(row.string("status")),
             temaer = hentTema(planIdLestFraDB, session),
         )

--- a/src/main/kotlin/no/nav/lydia/ia/sak/domene/plan/Plan.kt
+++ b/src/main/kotlin/no/nav/lydia/ia/sak/domene/plan/Plan.kt
@@ -9,7 +9,6 @@ data class Plan(
     val id: UUID,
     val samarbeidId: Int,
     val sistEndret: LocalDateTime,
-    val sistPublisert: LocalDate?,
     val status: IASamarbeid.Status,
     val temaer: List<PlanTema>,
 ) {

--- a/src/main/resources/db/migration/2026/V147__fjern_sist_publisert_fra_plan.sql
+++ b/src/main/resources/db/migration/2026/V147__fjern_sist_publisert_fra_plan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ia_sak_plan DROP COLUMN sist_publisert;

--- a/src/test/kotlin/no/nav/lydia/container/dokument/DokumentPubliseringApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/dokument/DokumentPubliseringApiTest.kt
@@ -5,6 +5,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromJsonElement
 import no.nav.lydia.Topic
@@ -19,6 +21,7 @@ import no.nav.lydia.helper.IASakSpørreundersøkelseHelper.Companion.start
 import no.nav.lydia.helper.IASakSpørreundersøkelseHelper.Companion.svarPåSpørsmål
 import no.nav.lydia.helper.PlanHelper.Companion.antallInnholdInkludert
 import no.nav.lydia.helper.PlanHelper.Companion.antallTemaInkludert
+import no.nav.lydia.helper.PlanHelper.Companion.hentPlan
 import no.nav.lydia.helper.PlanHelper.Companion.hentPlanMal
 import no.nav.lydia.helper.PlanHelper.Companion.inkluderAlt
 import no.nav.lydia.helper.PlanHelper.Companion.opprettEnPlan
@@ -40,6 +43,7 @@ import org.junit.AfterClass
 import org.junit.BeforeClass
 import java.util.UUID
 import kotlin.test.Test
+import kotlin.time.Clock
 
 class DokumentPubliseringApiTest {
     companion object {
@@ -398,5 +402,26 @@ class DokumentPubliseringApiTest {
                     }
             }
         }
+    }
+
+    @Test
+    fun `publiserte planer skal returnere sistPublisert i dto`() {
+        val sak = aktivSamarbeidsperiode()
+        val plan = sak.opprettEnPlan()
+        plan.sistPublisert shouldBe null
+
+        val response = publiserDokument(
+            dokumentReferanseId = plan.id,
+            dokumentType = DokumentPubliseringDto.Type.SAMARBEIDSPLAN,
+            token = authContainerHelper.saksbehandler1.token,
+        )
+        sendKvittering(
+            dokument = response.third.get(),
+            samarbeidId = sak.hentAlleSamarbeid().first().id,
+        )
+
+        val publisertPlan = sak.hentPlan()
+        publisertPlan.sistPublisert shouldNotBe null
+        publisertPlan.sistPublisert?.date shouldBe Clock.System.todayIn(TimeZone.currentSystemDefault())
     }
 }

--- a/src/test/kotlin/no/nav/lydia/container/ia/eksport/SamarbeidsplanProdusentTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/eksport/SamarbeidsplanProdusentTest.kt
@@ -24,7 +24,7 @@ import no.nav.lydia.helper.forExactlyOne
 import no.nav.lydia.helper.hentAlleSamarbeid
 import no.nav.lydia.ia.eksport.SamarbeidsplanKafkaMelding
 import no.nav.lydia.ia.sak.api.IASakDto
-import no.nav.lydia.ia.sak.api.plan.PlanDtoI
+import no.nav.lydia.ia.sak.api.plan.PlanDto
 import no.nav.lydia.ia.sak.api.samarbeid.IASamarbeidDto
 import no.nav.lydia.ia.sak.domene.plan.PlanMalDto
 import no.nav.lydia.ia.sak.domene.plan.PlanUndertema
@@ -173,7 +173,7 @@ class SamarbeidsplanProdusentTest {
     private suspend fun konsummerOgSjekkKafkaMelding(
         sakDto: IASakDto,
         samarbeidDto: IASamarbeidDto,
-        planDto: PlanDtoI,
+        planDto: PlanDto,
         startDato: LocalDate? = null,
         sluttDato: LocalDate? = null,
     ) {
@@ -199,7 +199,7 @@ class SamarbeidsplanProdusentTest {
         planTilSalesforce: SamarbeidsplanKafkaMelding,
         sak: IASakDto,
         samarbeid: IASamarbeidDto,
-        opprettetPlan: PlanDtoI,
+        opprettetPlan: PlanDto,
         startDato: LocalDate?,
         sluttDato: LocalDate?,
     ) {

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -52,7 +52,7 @@ import no.nav.lydia.ia.sak.api.ny.flyt.NY_FLYT_PATH
 import no.nav.lydia.ia.sak.api.ny.flyt.VirksomhetTilstandDto
 import no.nav.lydia.ia.sak.api.plan.EndreTemaRequest
 import no.nav.lydia.ia.sak.api.plan.EndreUndertemaRequest
-import no.nav.lydia.ia.sak.api.plan.PlanMedPubliseringStatusDto
+import no.nav.lydia.ia.sak.api.plan.PlanDto
 import no.nav.lydia.ia.sak.api.samarbeid.IASamarbeidDto
 import no.nav.lydia.ia.sak.domene.IASak
 import no.nav.lydia.ia.sak.domene.IASakshendelseType
@@ -129,7 +129,7 @@ class NyFlytTestUtils {
         fun verifiserKafkaPlanObserversErVarslet(
             iASakDto: IASakDto,
             iASamarbeidDto: IASamarbeidDto,
-            plan: PlanMedPubliseringStatusDto,
+            plan: PlanDto,
         ) {
             runBlocking {
                 kafkaContainerHelper.ventOgKonsumerKafkaMeldinger(
@@ -398,7 +398,7 @@ class NyFlytTestUtils {
             .authentication().bearer(token)
             .jsonBody(
                 Json.encodeToString(endringer),
-            ).tilSingelRespons<PlanMedPubliseringStatusDto>().third.fold(
+            ).tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
                 failure = { fail("${it.message}") },
             )
@@ -415,7 +415,7 @@ class NyFlytTestUtils {
             .authentication().bearer(token)
             .jsonBody(
                 Json.encodeToString(endringer),
-            ).tilSingelRespons<PlanMedPubliseringStatusDto>().third.fold(
+            ).tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
                 failure = { fail("${it.message}") },
             )
@@ -447,7 +447,7 @@ class NyFlytTestUtils {
             token: String = authContainerHelper.saksbehandler1.token,
         ) = applikasjon.performDelete("$NY_FLYT_API_PATH/virksomhet/$orgnr/samarbeidsperiode/${this.saksnummer}/samarbeid/${this.id}/plan/$planId")
             .authentication().bearer(token)
-            .tilSingelRespons<PlanMedPubliseringStatusDto>().third.fold(
+            .tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
                 failure = { fail(it.message) },
             )
@@ -465,18 +465,18 @@ class NyFlytTestUtils {
             .authentication().bearer(token)
             .jsonBody(
                 Json.encodeToString(nyStatus),
-            ).tilSingelRespons<PlanMedPubliseringStatusDto>().third.fold(
+            ).tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
                 failure = { fail("${it.message}") },
             )
 
-        fun PlanMedPubliseringStatusDto.endreTema(
+        fun PlanDto.endreTema(
             temaId: Int,
             inkluderTema: Boolean = true,
             inkluderUnderTema: Boolean = true,
             nyStartDato: LocalDate? = null,
             nySluttDato: LocalDate? = null,
-        ): PlanMedPubliseringStatusDto =
+        ): PlanDto =
             this.copy(
                 temaer = this.temaer.map { tema ->
                     if (tema.id == temaId) {

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/plan/NyFlytSamarbeidsplanTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/plan/NyFlytSamarbeidsplanTest.kt
@@ -30,7 +30,7 @@ import no.nav.lydia.helper.SakHelper.Companion.leggTilFolger
 import no.nav.lydia.helper.TestContainerHelper.Companion.authContainerHelper
 import no.nav.lydia.helper.TestContainerHelper.Companion.kafkaContainerHelper
 import no.nav.lydia.ia.sak.api.ny.flyt.VirksomhetIATilstand
-import no.nav.lydia.ia.sak.api.plan.PlanMedPubliseringStatusDto
+import no.nav.lydia.ia.sak.api.plan.PlanDto
 import no.nav.lydia.ia.sak.domene.IASak
 import no.nav.lydia.ia.sak.domene.plan.InnholdMalDto
 import no.nav.lydia.ia.sak.domene.plan.PlanMalDto
@@ -100,7 +100,7 @@ class NyFlytSamarbeidsplanTest {
         val sak = vurderVirksomhet()
         sak.leggTilFolger(authContainerHelper.saksbehandler1.token)
         val samarbeid = sak.opprettSamarbeid(authContainerHelper.saksbehandler1.token)
-        val opprinneligPlan: PlanMedPubliseringStatusDto = samarbeid.opprettSamarbeidsplan(sak.orgnr, token = authContainerHelper.saksbehandler1.token)
+        val opprinneligPlan: PlanDto = samarbeid.opprettSamarbeidsplan(sak.orgnr, token = authContainerHelper.saksbehandler1.token)
 
         // Gjør bare en endring på sluttDato i første tema og eksluder andre tema
 
@@ -140,7 +140,7 @@ class NyFlytSamarbeidsplanTest {
         val sak = vurderVirksomhet()
         sak.leggTilFolger(authContainerHelper.saksbehandler1.token)
         val samarbeid = sak.opprettSamarbeid(authContainerHelper.saksbehandler1.token)
-        val opprinneligPlan: PlanMedPubliseringStatusDto = samarbeid.opprettSamarbeidsplan(orgnr = sak.orgnr, token = authContainerHelper.saksbehandler1.token)
+        val opprinneligPlan: PlanDto = samarbeid.opprettSamarbeidsplan(orgnr = sak.orgnr, token = authContainerHelper.saksbehandler1.token)
         val førsteTema = opprinneligPlan.temaer.first()
         val førsteUndertema = førsteTema.undertemaer.first()
         førsteUndertema.inkludert shouldBe true
@@ -205,7 +205,7 @@ class NyFlytSamarbeidsplanTest {
         val sak = vurderVirksomhet()
         sak.leggTilFolger(authContainerHelper.saksbehandler1.token)
         val samarbeid = sak.opprettSamarbeid(authContainerHelper.saksbehandler1.token)
-        val opprinneligPlan: PlanMedPubliseringStatusDto = samarbeid.opprettSamarbeidsplan(sak.orgnr, token = authContainerHelper.saksbehandler1.token)
+        val opprinneligPlan: PlanDto = samarbeid.opprettSamarbeidsplan(sak.orgnr, token = authContainerHelper.saksbehandler1.token)
 
         // Gjør bare en endring på sluttDato i første tema og eksluder andre tema
 

--- a/src/test/kotlin/no/nav/lydia/helper/PlanHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/PlanHelper.kt
@@ -13,8 +13,6 @@ import no.nav.lydia.ia.sak.api.plan.EndreTemaRequest
 import no.nav.lydia.ia.sak.api.plan.EndreUndertemaRequest
 import no.nav.lydia.ia.sak.api.plan.PLAN_BASE_ROUTE
 import no.nav.lydia.ia.sak.api.plan.PlanDto
-import no.nav.lydia.ia.sak.api.plan.PlanDtoI
-import no.nav.lydia.ia.sak.api.plan.PlanMedPubliseringStatusDto
 import no.nav.lydia.ia.sak.api.plan.PlanUndertemaDto
 import no.nav.lydia.ia.sak.api.samarbeid.IASamarbeidDto
 import no.nav.lydia.ia.sak.domene.plan.InnholdMalDto
@@ -28,22 +26,22 @@ class PlanHelper {
         val START_DATO = LocalDate(year = 2021, monthNumber = 1, dayOfMonth = 1)
         val SLUTT_DATO = LocalDate(year = 2022, monthNumber = 2, dayOfMonth = 2)
 
-        fun PlanDtoI.antallTemaInkludert() = temaer.filter { it.inkludert }.size
+        fun PlanDto.antallTemaInkludert() = temaer.filter { it.inkludert }.size
 
-        fun PlanDtoI.antallInnholdInkludert() = temaer.flatMap { it.undertemaer }.filter { it.inkludert }.size
+        fun PlanDto.antallInnholdInkludert() = temaer.flatMap { it.undertemaer }.filter { it.inkludert }.size
 
-        fun PlanDtoI.antallInnholdMedStatus(status: PlanUndertema.Status) =
+        fun PlanDto.antallInnholdMedStatus(status: PlanUndertema.Status) =
             temaer.flatMap { it.undertemaer }.filter {
                 it.inkludert &&
                     it.status == status
             }.size
 
-        fun PlanDtoI.tidligstStartDato(): LocalDate =
+        fun PlanDto.tidligstStartDato(): LocalDate =
             this.temaer.flatMap { it.undertemaer }
                 .filter { it.startDato != null }
                 .minOf { it.startDato!! }
 
-        fun PlanDtoI.senesteSluttDato(): LocalDate =
+        fun PlanDto.senesteSluttDato(): LocalDate =
             this.temaer.flatMap { it.undertemaer }
                 .filter { it.sluttDato != null }
                 .maxOf { it.sluttDato!! }
@@ -64,7 +62,7 @@ class PlanHelper {
             token: String = TestContainerHelper.authContainerHelper.saksbehandler1.token,
         ) = TestContainerHelper.applikasjon.performGet("${PLAN_BASE_ROUTE}/$orgnr/$saksnummer/prosess/$samarbeidId")
             .authentication().bearer(token)
-            .tilSingelRespons<PlanMedPubliseringStatusDto>()
+            .tilSingelRespons<PlanDto>()
 
         private fun hentPlan(
             orgnr: String,
@@ -73,7 +71,7 @@ class PlanHelper {
             token: String = TestContainerHelper.authContainerHelper.saksbehandler1.token,
         ) = TestContainerHelper.applikasjon.performGet("${PLAN_BASE_ROUTE}/$orgnr/$saksnummer/prosess/$prosessId")
             .authentication().bearer(token)
-            .tilSingelRespons<PlanMedPubliseringStatusDto>().third.fold(
+            .tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
                 failure = { fail(it.message) },
             )
@@ -197,11 +195,11 @@ class PlanHelper {
                 )
             }
 
-        fun PlanMedPubliseringStatusDto.inkluderTemaOgAltInnhold(
+        fun PlanDto.inkluderTemaOgAltInnhold(
             temaId: Int,
             startDato: LocalDate = START_DATO,
             sluttDato: LocalDate = SLUTT_DATO,
-        ): PlanMedPubliseringStatusDto =
+        ): PlanDto =
             this.copy(
                 temaer = temaer.map { tema ->
                     if (tema.id == temaId) {
@@ -234,22 +232,6 @@ class PlanHelper {
                 },
             )
 
-        fun PlanMedPubliseringStatusDto.inkluderAlt(
-            startDato: LocalDate = START_DATO,
-            sluttDato: LocalDate = SLUTT_DATO,
-        ): PlanMedPubliseringStatusDto =
-            this.copy(
-                temaer = temaer.map { tema ->
-                    tema.copy(
-                        inkludert = true,
-                        undertemaer = tema.undertemaer.inkluderAltInnhold(
-                            startDato = startDato,
-                            sluttDato = sluttDato,
-                        ),
-                    )
-                },
-            )
-
         // TODO: [OPPRYDDING] Bør gå bort ifra denne måten å opprette planer
         fun IASakDto.opprettEnPlan(
             token: String = TestContainerHelper.authContainerHelper.saksbehandler1.token,
@@ -268,7 +250,7 @@ class PlanHelper {
             .authentication().bearer(token)
             .jsonBody(
                 Json.encodeToString(planMal),
-            ).tilSingelRespons<PlanMedPubliseringStatusDto>().third.fold(
+            ).tilSingelRespons<PlanDto>().third.fold(
                 success = { it },
                 failure = { fail(it.message) },
             )
@@ -284,7 +266,7 @@ class PlanHelper {
         )
             .jsonBody(Json.encodeToString(endring))
             .authentication().bearer(token)
-            .tilSingelRespons<PlanMedPubliseringStatusDto>().third.fold(
+            .tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
                 failure = { fail(it.message) },
             )
@@ -299,7 +281,7 @@ class PlanHelper {
         )
             .jsonBody(Json.encodeToString(endring))
             .authentication().bearer(token)
-            .tilSingelRespons<PlanMedPubliseringStatusDto>().third.fold(
+            .tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
                 failure = { fail(it.message) },
             )
@@ -316,7 +298,7 @@ class PlanHelper {
         )
             .jsonBody(Json.encodeToString(endring))
             .authentication().bearer(token)
-            .tilSingelRespons<PlanMedPubliseringStatusDto>().third.fold(
+            .tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
                 failure = { fail(it.message) },
             )
@@ -335,12 +317,12 @@ class PlanHelper {
         )
             .jsonBody(Json.encodeToString(status))
             .authentication().bearer(token)
-            .tilSingelRespons<PlanMedPubliseringStatusDto>().third.fold(
+            .tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
                 failure = { fail(it.message) },
             )
 
-        fun PlanDtoI.tilRequest(): List<EndreTemaRequest> =
+        fun PlanDto.tilRequest(): List<EndreTemaRequest> =
             this.temaer.map { tema ->
                 EndreTemaRequest(
                     tema.id,
@@ -367,7 +349,7 @@ class PlanHelper {
                     failure = { fail(it.message) },
                 )
 
-        fun PlanMedPubliseringStatusDto.planleggOgFullførAlleUndertemaer(
+        fun PlanDto.planleggOgFullførAlleUndertemaer(
             orgnummer: String,
             saksnummer: String,
             samarbeidId: Int,

--- a/src/test/kotlin/no/nav/lydia/ia/sak/domene/plan/PlanUnitTest.kt
+++ b/src/test/kotlin/no/nav/lydia/ia/sak/domene/plan/PlanUnitTest.kt
@@ -2,7 +2,6 @@ package no.nav.lydia.ia.sak.domene.plan
 
 import io.kotest.matchers.shouldBe
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.toKotlinLocalDate
 import kotlinx.datetime.toKotlinLocalDateTime
 import no.nav.lydia.ia.sak.domene.samarbeid.IASamarbeid
 import java.util.UUID
@@ -15,7 +14,6 @@ class PlanUnitTest {
             id = UUID.randomUUID(),
             samarbeidId = 1,
             sistEndret = java.time.LocalDateTime.now().toKotlinLocalDateTime(),
-            sistPublisert = java.time.LocalDate.now().toKotlinLocalDate(),
             status = IASamarbeid.Status.AKTIV,
             temaer = listOf(
                 PlanTema(


### PR DESCRIPTION
Fjerner sist_publisert fra ia_sak_plan, da den ikke er i bruk. Publiserings dato hentes fra dokument_til_publisering.

Refaktorer også litt rundt PlanDto.