### PR TITLE
Gjør valgt årsak obligatorisk i api på vurder virksomhet

### DIFF
--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -224,7 +224,14 @@ fun Route.nyFlyt(
         val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
         val valgtÅrsak = runCatching { call.receiveNullable<ValgtÅrsak>() }.getOrNull()
 
-        if (valgtÅrsak != null && !valgtÅrsak.validerBegrunnelserForVurderingAvVirksomhet()) {
+        if (valgtÅrsak == null) {
+            return@post call.respond(
+                status = HttpStatusCode.BadRequest,
+                message = "Mangler årsak og begrunnelse for vurdering av virksomhet",
+            )
+        }
+
+        if (!valgtÅrsak.validerBegrunnelserForVurderingAvVirksomhet()) {
             return@post call.respond(
                 status = HttpStatusCode.BadRequest,
                 message = "Ugyldig årsak eller begrunnelse for vurdering av virksomhet",

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
@@ -22,6 +22,8 @@ import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttVurdering
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.endreSamarbeidsNavn
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.hentVirksomhetTilstand
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.opprettSamarbeid
+import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.revurderVirksomhet
+import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.revurderVirksomhetResponse
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.slettSamarbeid
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.slettSamarbeidRespons
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.verifiserIASakObserversErVarslet
@@ -348,10 +350,7 @@ class NyFlytTest {
         virksomhetsTilstand.nesteTilstand.nyTilstand shouldBe VirksomhetIATilstand.VirksomhetKlarTilVurdering
         virksomhetsTilstand.nesteTilstand.planlagtDato shouldBe LocalDate.now().plusDays(1).toKotlinLocalDate()
 
-        val nySak = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/vurder")
-            .authentication().bearer(authContainerHelper.superbruker1.token)
-            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
-            .tilSingelRespons<IASakDto>().third.get()
+        val nySak = sak.revurderVirksomhet()
 
         nySak.orgnr shouldBe sak.orgnr
 
@@ -377,10 +376,7 @@ class NyFlytTest {
         virksomhetsTilstand.nesteTilstand?.nyTilstand shouldBe VirksomhetIATilstand.VirksomhetKlarTilVurdering
         virksomhetsTilstand.nesteTilstand?.planlagtDato shouldBe LocalDate.now().plusDays(90).toKotlinLocalDate()
 
-        val nySak = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/vurder")
-            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
-            .authentication().bearer(authContainerHelper.superbruker1.token)
-            .tilSingelRespons<IASakDto>().third.get()
+        val nySak = sak.revurderVirksomhet()
 
         nySak.orgnr shouldBe sak.orgnr
 
@@ -622,11 +618,7 @@ class NyFlytTest {
     @Test
     fun `vurder virksomhet returnerer 201 - CREATED`() {
         val virksomhet = lastInnNyVirksomhet()
-        val orgnummer = virksomhet.orgnr
-        val res = applikasjon.performPost("$NY_FLYT_PATH/$orgnummer/vurder")
-            .authentication().bearer(authContainerHelper.superbruker1.token)
-            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
-            .tilSingelRespons<IASakDto>()
+        val res = vurderVirksomhetResponse(virksomhet)
 
         res.second.statusCode shouldBe HttpStatusCode.Created.value
     }
@@ -989,10 +981,8 @@ class NyFlytTest {
         avsluttVurderingRes.second.statusCode shouldBe HttpStatusCode.OK.value
         avsluttVurderingRes.third.get().status shouldBe IASak.Status.VURDERT
 
-        val revurderRes = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/vurder")
-            .authentication().bearer(authContainerHelper.superbruker1.token)
-            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
-            .tilSingelRespons<IASakDto>()
+        val revurderRes = sak.revurderVirksomhetResponse()
+
         revurderRes.second.statusCode shouldBe HttpStatusCode.Created.value
         revurderRes.third.get().status shouldBe IASak.Status.VURDERES
 
@@ -1345,10 +1335,7 @@ class NyFlytTest {
         tilstandFørRevurdering.nesteTilstand shouldNotBe null
         tilstandFørRevurdering.nesteTilstand?.planlagtHendelse shouldBe "GjørVirksomhetKlarTilNyVurdering"
 
-        val revurderRes = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/vurder")
-            .authentication().bearer(authContainerHelper.superbruker1.token)
-            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
-            .tilSingelRespons<IASakDto>()
+        val revurderRes = sak.revurderVirksomhetResponse()
         revurderRes.second.statusCode shouldBe HttpStatusCode.Created.value
 
         val tilstandEtterRevurdering = hentVirksomhetTilstand(orgnr = sak.orgnr)
@@ -1366,10 +1353,7 @@ class NyFlytTest {
 
         hentVirksomhetTilstand(orgnr = sak.orgnr).tilstand shouldBe VirksomhetIATilstand.AlleSamarbeidIVirksomhetErAvsluttet
 
-        val revurderRes = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/vurder")
-            .authentication().bearer(authContainerHelper.superbruker1.token)
-            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
-            .tilSingelRespons<IASakDto>()
+        val revurderRes = sak.revurderVirksomhetResponse()
         revurderRes.second.statusCode shouldBe HttpStatusCode.Created.value
         revurderRes.third.get().status shouldBe IASak.Status.VURDERES
 

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
@@ -350,6 +350,7 @@ class NyFlytTest {
 
         val nySak = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/vurder")
             .authentication().bearer(authContainerHelper.superbruker1.token)
+            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
             .tilSingelRespons<IASakDto>().third.get()
 
         nySak.orgnr shouldBe sak.orgnr
@@ -377,6 +378,7 @@ class NyFlytTest {
         virksomhetsTilstand.nesteTilstand?.planlagtDato shouldBe LocalDate.now().plusDays(90).toKotlinLocalDate()
 
         val nySak = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/vurder")
+            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
             .authentication().bearer(authContainerHelper.superbruker1.token)
             .tilSingelRespons<IASakDto>().third.get()
 
@@ -623,6 +625,7 @@ class NyFlytTest {
         val orgnummer = virksomhet.orgnr
         val res = applikasjon.performPost("$NY_FLYT_PATH/$orgnummer/vurder")
             .authentication().bearer(authContainerHelper.superbruker1.token)
+            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
             .tilSingelRespons<IASakDto>()
 
         res.second.statusCode shouldBe HttpStatusCode.Created.value
@@ -671,22 +674,6 @@ class NyFlytTest {
             """.trimIndent(),
         )
         begrunnelser shouldBe listOf(BegrunnelseType.VIRKSOMHETEN_HAR_TATT_KONTAKT.name)
-    }
-
-    @Test
-    fun `vurder virksomhet uten bakgrunn lagrer ingen begrunnelse`() {
-        val virksomhet = lastInnNyVirksomhet()
-        val sak = vurderVirksomhet(virksomhet = virksomhet)
-
-        val antallBegrunnelser = postgresContainerHelper.hentEnkelKolonne<Long>(
-            """
-            SELECT count(*)
-                 FROM hendelse_begrunnelse hb
-                 JOIN ia_sak_hendelse h ON h.id = hb.hendelse_id
-                 WHERE h.orgnr = '${sak.orgnr}'
-            """.trimIndent(),
-        )
-        antallBegrunnelser shouldBe 0L
     }
 
     @Test
@@ -751,7 +738,7 @@ class NyFlytTest {
                  WHERE h.orgnr = '${sak.orgnr}' AND h.type = '${IASakshendelseType.VIRKSOMHET_VURDERES.name}'
             """.trimIndent(),
         )
-        begrunnelser shouldBe listOf(BegrunnelseType.VIRKSOMHETEN_HAR_TATT_KONTAKT.name)
+        begrunnelser shouldBe listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN.name, BegrunnelseType.VIRKSOMHETEN_HAR_TATT_KONTAKT.name)
     }
 
     @Test
@@ -781,7 +768,7 @@ class NyFlytTest {
                  WHERE h.orgnr = '${sak.orgnr}' AND h.type = '${IASakshendelseType.VIRKSOMHET_VURDERES.name}'
             """.trimIndent(),
         )
-        begrunnelser shouldBe listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN.name)
+        begrunnelser shouldBe listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN.name, BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN.name)
     }
 
     @Test
@@ -802,11 +789,13 @@ class NyFlytTest {
         val orgnummer = VirksomhetHelper.nyttOrgnummer()
         val res1 = applikasjon.performPost("$NY_FLYT_PATH/$orgnummer/vurder")
             .authentication().bearer(authContainerHelper.lesebruker.token)
+            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
             .tilSingelRespons<IASakDto>()
         res1.second.statusCode shouldBe HttpStatusCode.Forbidden.value
 
         val res2 = applikasjon.performPost("$NY_FLYT_PATH/$orgnummer/vurder")
             .authentication().bearer(authContainerHelper.saksbehandler1.token)
+            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
             .tilSingelRespons<IASakDto>()
         res2.second.statusCode shouldBe HttpStatusCode.Forbidden.value
     }
@@ -1002,6 +991,7 @@ class NyFlytTest {
 
         val revurderRes = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/vurder")
             .authentication().bearer(authContainerHelper.superbruker1.token)
+            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
             .tilSingelRespons<IASakDto>()
         revurderRes.second.statusCode shouldBe HttpStatusCode.Created.value
         revurderRes.third.get().status shouldBe IASak.Status.VURDERES
@@ -1357,6 +1347,7 @@ class NyFlytTest {
 
         val revurderRes = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/vurder")
             .authentication().bearer(authContainerHelper.superbruker1.token)
+            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
             .tilSingelRespons<IASakDto>()
         revurderRes.second.statusCode shouldBe HttpStatusCode.Created.value
 
@@ -1377,6 +1368,7 @@ class NyFlytTest {
 
         val revurderRes = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/vurder")
             .authentication().bearer(authContainerHelper.superbruker1.token)
+            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
             .tilSingelRespons<IASakDto>()
         revurderRes.second.statusCode shouldBe HttpStatusCode.Created.value
         revurderRes.third.get().status shouldBe IASak.Status.VURDERES

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -242,16 +242,22 @@ class NyFlytTestUtils {
         fun vurderVirksomhetResponse(
             virksomhet: TestVirksomhet = lastInnNyVirksomhet(),
             token: String = authContainerHelper.superbruker1.token,
-            valgtÅrsak: ValgtÅrsak? = null,
+            valgtÅrsak: ValgtÅrsak = ValgtÅrsak(
+                ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET,
+                listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN),
+            ),
         ) = applikasjon.performPost("$NY_FLYT_PATH/${virksomhet.orgnr}/vurder")
             .authentication().bearer(token)
-            .apply { valgtÅrsak?.let { jsonBody(Json.encodeToString(it)) } }
+            .jsonBody(Json.encodeToString(valgtÅrsak))
             .tilSingelRespons<IASakDto>()
 
         fun vurderVirksomhet(
             virksomhet: TestVirksomhet = lastInnNyVirksomhet(),
             token: String = authContainerHelper.superbruker1.token,
-            valgtÅrsak: ValgtÅrsak? = null,
+            valgtÅrsak: ValgtÅrsak = ValgtÅrsak(
+                ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET,
+                listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN),
+            ),
         ) = vurderVirksomhetResponse(virksomhet = virksomhet, token = token, valgtÅrsak = valgtÅrsak).third.fold(
             success = { it },
             failure = { fail(it.message) },

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -238,6 +238,15 @@ class NyFlytTestUtils {
             }
         }
 
+        private fun vurderVirksomhetMedOrgnrResponse(
+            orgnr: String,
+            token: String = authContainerHelper.superbruker1.token,
+            valgtÅrsak: ValgtÅrsak = ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN)),
+        ) = applikasjon.performPost("$NY_FLYT_PATH/$orgnr/vurder")
+            .authentication().bearer(token)
+            .jsonBody(Json.encodeToString(valgtÅrsak))
+            .tilSingelRespons<IASakDto>()
+
         // Test-case utils
         fun vurderVirksomhetResponse(
             virksomhet: TestVirksomhet = lastInnNyVirksomhet(),
@@ -246,10 +255,7 @@ class NyFlytTestUtils {
                 ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET,
                 listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN),
             ),
-        ) = applikasjon.performPost("$NY_FLYT_PATH/${virksomhet.orgnr}/vurder")
-            .authentication().bearer(token)
-            .jsonBody(Json.encodeToString(valgtÅrsak))
-            .tilSingelRespons<IASakDto>()
+        ) = vurderVirksomhetMedOrgnrResponse(virksomhet.orgnr, token, valgtÅrsak)
 
         fun vurderVirksomhet(
             virksomhet: TestVirksomhet = lastInnNyVirksomhet(),
@@ -259,6 +265,25 @@ class NyFlytTestUtils {
                 listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN),
             ),
         ) = vurderVirksomhetResponse(virksomhet = virksomhet, token = token, valgtÅrsak = valgtÅrsak).third.fold(
+            success = { it },
+            failure = { fail(it.message) },
+        )
+
+        fun IASakDto.revurderVirksomhetResponse(
+            token: String = authContainerHelper.superbruker1.token,
+            valgtÅrsak: ValgtÅrsak = ValgtÅrsak(
+                ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET,
+                listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN),
+            ),
+        ) = vurderVirksomhetMedOrgnrResponse(orgnr, token, valgtÅrsak)
+
+        fun IASakDto.revurderVirksomhet(
+            token: String = authContainerHelper.superbruker1.token,
+            valgtÅrsak: ValgtÅrsak = ValgtÅrsak(
+                ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET,
+                listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN),
+            ),
+        ) = revurderVirksomhetResponse().third.fold(
             success = { it },
             failure = { fail(it.message) },
         )


### PR DESCRIPTION
Bakgrunnen for å ikke gjøre den obligatorisk på typenivå, er at vi har automatiske vurderinger som opprettes uten årsak. Det har blitt laget en sak på å lage en egen årsak for automatisk vurdering:)