### PR TITLE
Sett opp teamlogs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/slett-ubrukte-felter-ia-sak-dto'
+    if: github.ref == 'refs/heads/teamlogs'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -40,6 +40,8 @@ spec:
   accessPolicy:
     outbound:
       rules:
+        - application: logging
+          namespace: nais-system
         - application: pia-pdfgen
       external:
         - host: {{journalpostHost}}

--- a/src/main/kotlin/no/nav/lydia/App.kt
+++ b/src/main/kotlin/no/nav/lydia/App.kt
@@ -125,8 +125,7 @@ fun main() {
 
 fun startLydiaBackend() {
     val log = LoggerFactory.getLogger("App")
-    log.info("Starter Fia backend")
-    log.tlinfo("Hei fra teamlog")
+    log.info("Starter Lydia backend")
 
     val naisEnv = NaisEnvironment()
 

--- a/src/main/kotlin/no/nav/lydia/App.kt
+++ b/src/main/kotlin/no/nav/lydia/App.kt
@@ -114,7 +114,8 @@ import no.nav.lydia.tilgangskontroll.obo.OboTokenUtveksler
 import no.nav.lydia.tilstandsmaskin.NyFlytService
 import no.nav.lydia.tilstandsmaskin.TilstandVirksomhetOppdaterer
 import no.nav.lydia.tilstandsmaskin.TilstandVirksomhetRepository
-import java.util.*
+import org.slf4j.LoggerFactory
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import javax.sql.DataSource
 
@@ -123,6 +124,10 @@ fun main() {
 }
 
 fun startLydiaBackend() {
+    val log = LoggerFactory.getLogger("App")
+    log.info("Starter Fia backend")
+    log.tlinfo("Hei fra teamlog")
+
     val naisEnv = NaisEnvironment()
 
     val dataSource = createDataSource(database = naisEnv.database)

--- a/src/main/kotlin/no/nav/lydia/TeamLog.kt
+++ b/src/main/kotlin/no/nav/lydia/TeamLog.kt
@@ -10,5 +10,7 @@ fun Logger.tldebug(msg: String) = debug(teamLogsMarker, msg)
 fun Logger.tlinfo(msg: String) = info(teamLogsMarker, msg)
 
 fun Logger.tlwarn(msg: String) = warn(teamLogsMarker, msg)
+fun Logger.tlwarn(msg: String, t: Throwable) = warn(teamLogsMarker, msg, t)
 
 fun Logger.tlerror(msg: String) = error(teamLogsMarker, msg)
+fun Logger.tlerror(msg: String, t: Throwable) = error(teamLogsMarker, msg, t)

--- a/src/main/kotlin/no/nav/lydia/TeamLog.kt
+++ b/src/main/kotlin/no/nav/lydia/TeamLog.kt
@@ -1,0 +1,14 @@
+package no.nav.lydia
+
+import org.slf4j.Logger
+import org.slf4j.MarkerFactory
+
+private val teamLogsMarker = MarkerFactory.getMarker("TEAM_LOGS")
+
+fun Logger.tldebug(msg: String) = debug(teamLogsMarker, msg)
+
+fun Logger.tlinfo(msg: String) = info(teamLogsMarker, msg)
+
+fun Logger.tlwarn(msg: String) = warn(teamLogsMarker, msg)
+
+fun Logger.tlerror(msg: String) = error(teamLogsMarker, msg)

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <configuration>
     <appender name="stdout_json" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>TEAM_LOGS</marker>
+            </evaluator>
+            <OnMatch>DENY</OnMatch>
+            <OnMismatch>ACCEPT</OnMismatch>
+        </filter>
     </appender>
 
     <appender name="auditLogger" class="com.papertrailapp.logback.Syslog4jAppender">
@@ -14,7 +21,49 @@
             <ident>lydia-api</ident>
             <maxMessageLength>128000</maxMessageLength>
         </syslogConfig>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>TEAM_LOGS</marker>
+            </evaluator>
+            <OnMatch>DENY</OnMatch>
+            <OnMismatch>ACCEPT</OnMismatch>
+        </filter>
     </appender>
+
+    <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
+        <key>LOKAL_TEAM_LOGS</key>
+        <value>1</value>
+    </condition>
+    <if>
+        <then>
+            <appender name="team-logs" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+                <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+                    <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                        <marker>TEAM_LOGS</marker>
+                    </evaluator>
+                    <OnMatch>ACCEPT</OnMatch>
+                    <OnMismatch>DENY</OnMismatch>
+                </filter>
+            </appender>
+        </then>
+        <else>
+            <appender name="team-logs" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+                <destination>team-logs.nais-system:5170</destination>
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                    <customFields>{"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}</customFields>
+                    <includeContext>false</includeContext>
+                </encoder>
+                <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+                    <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                        <marker>TEAM_LOGS</marker>
+                    </evaluator>
+                    <OnMatch>ACCEPT</OnMatch>
+                    <OnMismatch>DENY</OnMismatch>
+                </filter>
+            </appender>
+        </else>
+    </if>
 
     <appender name="OTEL" class="io.opentelemetry.instrumentation.logback.mdc.v1_0.OpenTelemetryAppender">
         <appender-ref ref="stdout_json" />
@@ -22,6 +71,7 @@
 
     <root level="INFO">
         <appender-ref ref="OTEL" />
+        <appender-ref ref="team-logs" />
     </root>
     <logger level="INFO" name="auditLogger" additivity="false">
         <appender-ref ref="auditLogger" />

--- a/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
@@ -65,6 +65,7 @@ class TestContainerHelper {
                     "CONSUMER_LOOP_DELAY" to "1",
                     "NAIS_CLUSTER_NAME" to "lokal",
                     "PIA_PDFGEN_URL" to "http://pia-pdfgen",
+                    "LOKAL_TEAM_LOGS" to "1",
                 )
                     .plus(authContainerHelper.envVars())
                     .plus(kafkaContainerHelper.envVars())


### PR DESCRIPTION
Første utkast på oppsett av teamlogs.

Har lagt til fire extension functions på Logger `tldebug`, `tlinfo`, `tlwarn` og `tlerror`. Disse sørger for å sette riktig marker på loglinjene, og sender de så til teamlogs. For å finne de igjen sjekk https://doc.nais.io/observability/logging/how-to/team-logs/#accessing-team-logs

Gjenstående forbedringspunkter:

- Er de godt nok markert, slik at man ikke ved en feil logger til feil instans?
- Ekstra kompleksitet i logback.xml for å hindre exceptions ved oppstart. Er det verdt det? Kan det løses bedre?