### PR TITLE
Erstatte fuel med ktor http client

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,7 +70,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/teamlogs'
+    if: github.ref == 'refs/heads/erstatte-fuel-med-ktor-http-client'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val ktorVersion = "3.5.1"
-val fuelVersion = "2.3.1"
 val iaFellesVersion = "2.0.6"
 val kotestVerstion = "6.2.3"
 val testcontainersVersion = "2.0.5"
@@ -60,8 +59,7 @@ dependencies {
     implementation("org.flywaydb:flyway-database-postgresql:12.11.0")
     implementation("com.github.seratch:kotliquery:1.9.1")
 
-    // Enklere httpklient
-    implementation("com.github.kittinunf.fuel:fuel:$fuelVersion")
+    // Serialization med Gson
     implementation("com.google.code.gson:gson:2.14.0")
 
     // Kafka
@@ -101,7 +99,6 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers-kafka:$testcontainersVersion")
 
     // Http-mocking
-    testImplementation("com.github.kittinunf.fuel:fuel-kotlinx-serialization:$fuelVersion")
     testImplementation("org.wiremock:wiremock-standalone:3.13.2")
 
     // Autentisering

--- a/src/main/kotlin/no/nav/lydia/api/DokumentPubliseringRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/DokumentPubliseringRoutes.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.api
 
-import arrow.core.flatMap
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.log
 import io.ktor.server.response.respond
@@ -10,9 +9,7 @@ import no.nav.lydia.ADGrupper
 import no.nav.lydia.dokumentpublisering.DokumentPubliseringService
 import no.nav.lydia.felles.Feil
 import no.nav.lydia.integrasjoner.azure.AzureService
-import no.nav.lydia.integrasjoner.azure.NavEnhet
-import no.nav.lydia.tilgangskontroll.fia.objectId
-import no.nav.lydia.tilgangskontroll.somSaksbehandler
+import no.nav.lydia.tilgangskontroll.somSaksbehandlerMedNavenhet
 
 const val DOKUMENT_PUBLISERING_BASE_ROUTE = "$IA_SAK_RADGIVER_PATH/dokument"
 
@@ -25,15 +22,13 @@ fun Route.dokumentPublisering(
         val dokumentType = call.dokumentType ?: return@post call.sendFeil(DokumentPubliseringError.`ugyldig type`)
         val dokumentReferanseId = call.dokumentReferanseId ?: return@post call.sendFeil(DokumentPubliseringError.`ugyldig id`)
 
-        call.somSaksbehandler(adGrupper = adGrupper) { saksbehandler ->
-            azureService.hentNavenhet(objectId = call.objectId()).flatMap { navEnhet: NavEnhet ->
-                dokumentPubliseringService.publiserDokument(
-                    dokumentType = dokumentType,
-                    dokumentReferanseId = dokumentReferanseId,
-                    opprettetAv = saksbehandler,
-                    navEnhet = navEnhet,
-                )
-            }
+        call.somSaksbehandlerMedNavenhet(adGrupper = adGrupper, azureService = azureService) { saksbehandler, navEnhet ->
+            dokumentPubliseringService.publiserDokument(
+                dokumentType = dokumentType,
+                dokumentReferanseId = dokumentReferanseId,
+                opprettetAv = saksbehandler,
+                navEnhet = navEnhet,
+            )
         }.onRight {
             call.respond(status = HttpStatusCode.Created, message = it)
         }.onLeft {

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytKartleggingRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytKartleggingRoutes.kt
@@ -1,7 +1,6 @@
 package no.nav.lydia.api
 
 import arrow.core.Either
-import arrow.core.flatMap
 import arrow.core.left
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
@@ -24,8 +23,7 @@ import no.nav.lydia.samarbeidsperiode.IASakService
 import no.nav.lydia.samarbeidsplan.PlanService
 import no.nav.lydia.team.IATeamService
 import no.nav.lydia.tilgangskontroll.fia.NavAnsatt
-import no.nav.lydia.tilgangskontroll.fia.objectId
-import no.nav.lydia.tilgangskontroll.somSaksbehandler
+import no.nav.lydia.tilgangskontroll.somSaksbehandlerMedNavenhet
 import no.nav.lydia.tilstandsmaskin.FiaKontekst
 import no.nav.lydia.tilstandsmaskin.NyFlytService
 import no.nav.lydia.tilstandsmaskin.TilstandVirksomhetRepository
@@ -49,13 +47,13 @@ fun Route.nyFlytKartlegging(
     auditLog: AuditLog,
     azureService: AzureService,
 ) {
-    fun <T> ApplicationCall.somEierEllerFølgerAvSakMedNavenhet(
+    suspend fun <T> ApplicationCall.somEierEllerFølgerAvSakMedNavenhet(
         block: (NavAnsatt.NavAnsattMedSaksbehandlerRolle, NavEnhet, String, String) -> Either<Feil, T>,
-    ) = somSaksbehandler(adGrupper) { saksbehandler ->
-        val orgnummer = orgnummer ?: return@somSaksbehandler IASakError.`ugyldig orgnummer`.left()
-        val saksnummer = saksnummer ?: return@somSaksbehandler IASakError.`ugyldig saksnummer`.left()
+    ): Either<Feil, T> = somSaksbehandlerMedNavenhet(adGrupper, azureService) { saksbehandler, navEnhet ->
+        val orgnummer = orgnummer ?: return@somSaksbehandlerMedNavenhet IASakError.`ugyldig orgnummer`.left()
+        val saksnummer = saksnummer ?: return@somSaksbehandlerMedNavenhet IASakError.`ugyldig saksnummer`.left()
         val iaSak = iaSakService.hentIASakDto(saksnummer = saksnummer).getOrNull()
-            ?: return@somSaksbehandler IASakError.`ugyldig saksnummer`.left()
+            ?: return@somSaksbehandlerMedNavenhet IASakError.`ugyldig saksnummer`.left()
 
         if (iaSak.orgnr != orgnummer) {
             IASakError.`ugyldig orgnummer`.left()
@@ -67,9 +65,7 @@ fun Route.nyFlytKartlegging(
         ) {
             IASakError.`er ikke følger eller eier av sak`.left()
         } else {
-            azureService.hentNavenhet(objectId()).flatMap { navEnhet ->
-                block(saksbehandler, navEnhet, orgnummer, saksnummer)
-            }
+            block(saksbehandler, navEnhet, orgnummer, saksnummer)
         }
     }
 

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidsplanRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidsplanRoutes.kt
@@ -1,7 +1,6 @@
 package no.nav.lydia.api
 
 import arrow.core.Either
-import arrow.core.flatMap
 import arrow.core.left
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
@@ -32,8 +31,7 @@ import no.nav.lydia.samarbeidsplan.PlanUndertema
 import no.nav.lydia.samarbeidsplan.tilDtoMedPubliseringStatus
 import no.nav.lydia.team.IATeamService
 import no.nav.lydia.tilgangskontroll.fia.NavAnsatt
-import no.nav.lydia.tilgangskontroll.fia.objectId
-import no.nav.lydia.tilgangskontroll.somSaksbehandler
+import no.nav.lydia.tilgangskontroll.somSaksbehandlerMedNavenhet
 import no.nav.lydia.tilstandsmaskin.FiaKontekst
 import no.nav.lydia.tilstandsmaskin.NyFlytService
 import no.nav.lydia.tilstandsmaskin.TilstandVirksomhetRepository
@@ -59,16 +57,16 @@ fun Route.nyFlytSamarbeidsplan(
     auditLog: AuditLog,
     azureService: AzureService,
 ) {
-    fun <T> ApplicationCall.somEierEllerFølgerAvSakMedNavenhet(
+    suspend fun <T> ApplicationCall.somEierEllerFølgerAvSakMedNavenhet(
         iaSakService: IASakService,
         iaTeamService: IATeamService,
         adGrupper: ADGrupper,
         block: (NavAnsatt.NavAnsattMedSaksbehandlerRolle, NavEnhet, String, String) -> Either<Feil, T>,
-    ) = somSaksbehandler(adGrupper) { saksbehandler ->
-        val orgnummer = orgnummer ?: return@somSaksbehandler IASakError.`ugyldig orgnummer`.left()
-        val saksnummer = saksnummer ?: return@somSaksbehandler IASakError.`ugyldig saksnummer`.left()
+    ): Either<Feil, T> = somSaksbehandlerMedNavenhet(adGrupper, azureService) { saksbehandler, navEnhet ->
+        val orgnummer = orgnummer ?: return@somSaksbehandlerMedNavenhet IASakError.`ugyldig orgnummer`.left()
+        val saksnummer = saksnummer ?: return@somSaksbehandlerMedNavenhet IASakError.`ugyldig saksnummer`.left()
         val iaSak = iaSakService.hentIASakDto(saksnummer = saksnummer).getOrNull()
-            ?: return@somSaksbehandler IASakError.`ugyldig saksnummer`.left()
+            ?: return@somSaksbehandlerMedNavenhet IASakError.`ugyldig saksnummer`.left()
 
         if (iaSak.orgnr != orgnummer) {
             IASakError.`ugyldig orgnummer`.left()
@@ -80,9 +78,7 @@ fun Route.nyFlytSamarbeidsplan(
         ) {
             IASakError.`er ikke følger eller eier av sak`.left()
         } else {
-            azureService.hentNavenhet(objectId()).flatMap { navEnhet ->
-                block(saksbehandler, navEnhet, orgnummer, saksnummer)
-            }
+            block(saksbehandler, navEnhet, orgnummer, saksnummer)
         }
     }
 

--- a/src/main/kotlin/no/nav/lydia/integrasjoner/azure/AzureService.kt
+++ b/src/main/kotlin/no/nav/lydia/integrasjoner/azure/AzureService.kt
@@ -3,10 +3,14 @@ package no.nav.lydia.integrasjoner.azure
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
-import com.github.kittinunf.fuel.core.extensions.authentication
-import com.github.kittinunf.fuel.httpGet
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -62,8 +66,9 @@ class AzureService(
     private val log = LoggerFactory.getLogger(this::class.java)
     private val azureAdProps = "id,givenName,surname,onPremisesSamAccountName,streetAddress,department,city"
     private val deserializer = Json { ignoreUnknownKeys = true }
+    private val httpClient = HttpClient(CIO)
 
-    fun hentNavenhet(objectId: String?): Either<Feil, NavEnhet> {
+    suspend fun hentNavenhet(objectId: String?): Either<Feil, NavEnhet> {
         val accessToken = tokenFetcher.clientCredentialsToken()
         val url = "${security.azureConfig.graphDatabaseUrl}/users/$objectId?\$select=$azureAdProps"
         return hentFraAzure(url, accessToken, AzureType.NAVENHET_FRA_INNLOGGET_BRUKER)
@@ -104,7 +109,7 @@ class AzureService(
             }.mapLeft { Feil(it.message ?: "Ukjent feil under henting av veiledere", HttpStatusCode.InternalServerError) }
         }
 
-    private fun hentBrukereForGruppe(
+    private suspend fun hentBrukereForGruppe(
         azureConfig: AzureConfig,
         gruppeId: String,
         accessToken: String,
@@ -137,30 +142,25 @@ class AzureService(
         BRUKERE_I_GRUPPE,
     }
 
-    private fun hentFraAzure(
+    private suspend fun hentFraAzure(
         url: String,
         accessToken: String,
         typeSpørring: AzureType,
-    ) = url.httpGet()
-        .authentication()
-        .bearer(token = accessToken)
-        .header(
-            HttpHeaders.Accept to "application/json",
-            HttpHeaders.ContentType to "application/json",
-            "ConsistencyLevel" to "eventual",
-        )
-        .response()
-        .third
-        .fold(success = {
-            it.toString(Charsets.UTF_8).right()
-        }, failure = {
+    ): Either<Feil, String> {
+        val response = httpClient.get(url) {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            header(HttpHeaders.Accept, "application/json")
+            header(HttpHeaders.ContentType, "application/json")
+            header("ConsistencyLevel", "eventual")
+        }
+        val body = response.bodyAsText()
+        return if (response.status.isSuccess()) {
+            body.right()
+        } else {
             Feil(
-                feilmelding = "Feilet under henting fra Azure (${typeSpørring.name}): ${it.message} ${
-                    it.errorData.toString(
-                        Charsets.UTF_8,
-                    )
-                }",
+                feilmelding = "Feilet under henting fra Azure (${typeSpørring.name}): ${response.status} $body",
                 httpStatusCode = HttpStatusCode.InternalServerError,
             ).left()
-        })
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/lydia/integrasjoner/azure/AzureTokenFetcher.kt
+++ b/src/main/kotlin/no/nav/lydia/integrasjoner/azure/AzureTokenFetcher.kt
@@ -2,8 +2,13 @@ package no.nav.lydia.integrasjoner.azure
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
-import com.github.kittinunf.fuel.httpPost
 import com.nimbusds.jose.jwk.RSAKey
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.http.parameters
 import kotlinx.serialization.json.Json
 import no.nav.lydia.NaisEnvironment
 import no.nav.lydia.tilgangskontroll.TokenResponse
@@ -26,7 +31,9 @@ class AzureTokenFetcher(
         ignoreUnknownKeys = true
     }
 
-    internal fun clientCredentialsToken(): String {
+    private val httpClient = HttpClient(CIO)
+
+    internal suspend fun clientCredentialsToken(): String {
         val now = Instant.now()
         val clientAssertion = JWT.create().apply {
             withKeyId(privateKey.keyID)
@@ -38,22 +45,22 @@ class AzureTokenFetcher(
             withNotBefore(Date.from(now))
             withExpiresAt(Date.from(now.plusSeconds(120)))
         }.sign(Algorithm.RSA256(null, privateKey.toRSAPrivateKey()))
-        val parameters = listOf(
-            "grant_type" to "client_credentials",
-            "scope" to "https://graph.microsoft.com/.default",
-            "client_id" to naisEnvironment.security.azureConfig.clientId,
-            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-            "client_assertion" to clientAssertion,
+
+        val response = httpClient.submitForm(
+            url = naisEnvironment.security.azureConfig.tokenEndpoint,
+            formParameters = parameters {
+                append("grant_type", "client_credentials")
+                append("scope", "https://graph.microsoft.com/.default")
+                append("client_id", naisEnvironment.security.azureConfig.clientId)
+                append("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+                append("client_assertion", clientAssertion)
+            },
         )
-        return naisEnvironment.security.azureConfig.tokenEndpoint
-            .httpPost(parameters = parameters)
-            .response()
-            .third
-            .fold(success = {
-                deserializer.decodeFromString<TokenResponse>(it.toString(charset = Charsets.UTF_8)).access_token
-            }, failure = {
-                log.error("Azure token feilet. Response body ${it.errorData.toString(Charsets.UTF_8)}")
-                throw AzureException("Feilet under henting av Azure token: ${it.message}", it)
-            })
+        val body = response.bodyAsText()
+        if (!response.status.isSuccess()) {
+            log.error("Azure token feilet. Response body $body")
+            throw AzureException("Feilet under henting av Azure token: ${response.status}", RuntimeException(body))
+        }
+        return deserializer.decodeFromString<TokenResponse>(body).access_token
     }
 }

--- a/src/main/kotlin/no/nav/lydia/integrasjoner/journalpost/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/lydia/integrasjoner/journalpost/JournalpostService.kt
@@ -4,10 +4,17 @@ import arrow.core.Either
 import arrow.core.flatMap
 import arrow.core.left
 import arrow.core.right
-import com.github.kittinunf.fuel.core.extensions.authentication
-import com.github.kittinunf.fuel.core.extensions.jsonBody
-import com.github.kittinunf.fuel.httpPost
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import no.nav.lydia.NaisEnvironment
@@ -32,6 +39,7 @@ class JournalpostService(
     private val json = Json {
         ignoreUnknownKeys = true
     }
+    private val httpClient = HttpClient(CIO)
 
     fun journalfør(
         spørreundersøkelse: Spørreundersøkelse,
@@ -90,23 +98,26 @@ class JournalpostService(
 
     private fun ByteArray.tilBase64() = String(Base64.getEncoder().encode(this))
 
-    private fun journalfør(
+    private suspend fun journalfør(
         journalpostDto: JournalpostDto,
         accessToken: String,
-    ) = url.httpPost(listOf("forsoekFerdigstill" to true))
-        .jsonBody(Json.encodeToString<JournalpostDto>(journalpostDto))
-        .authentication().bearer(accessToken)
-        .response().third.fold(
-            success = {
-                val resultat = json.decodeFromString<JournalpostResultatDto>(it.toString(charset = Charsets.UTF_8))
-                log.info("Journalførte $resultat")
-                resultat.right()
-            },
-            failure = {
-                log.error("Klarte ikke å journalføre", it)
-                JournalpostFeil.FeillendeJournalpost.left()
-            },
-        )
+    ): Either<Feil, JournalpostResultatDto> {
+        val response = httpClient.post(url) {
+            parameter("forsoekFerdigstill", true)
+            contentType(ContentType.Application.Json)
+            bearerAuth(accessToken)
+            setBody(Json.encodeToString<JournalpostDto>(journalpostDto))
+        }
+        val body = response.bodyAsText()
+        return if (response.status.isSuccess()) {
+            val resultat = json.decodeFromString<JournalpostResultatDto>(body)
+            log.info("Journalførte $resultat")
+            resultat.right()
+        } else {
+            log.error("Klarte ikke å journalføre: ${response.status} $body")
+            JournalpostFeil.FeillendeJournalpost.left()
+        }
+    }
 
     object JournalpostFeil {
         val FeillendeJournalpost = Feil(

--- a/src/main/kotlin/no/nav/lydia/integrasjoner/pdfgen/PiaPdfgenService.kt
+++ b/src/main/kotlin/no/nav/lydia/integrasjoner/pdfgen/PiaPdfgenService.kt
@@ -133,7 +133,7 @@ private fun Spørreundersøkelse.Type.tilPdftype() =
         Spørreundersøkelse.Type.Behovsvurdering -> PdfType.BEHOVSVURDERING
     }
 
-val lokalTestPdf = Base64.decode(
+val lokalTestPdf: ByteArray = Base64.decode(
     """
     JVBERi0xLjQKMSAwIG9iago8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiAwIFI+PgplbmRvYmoKMiAw
     IG9iago8PC9UeXBlL1BhZ2VzL0tpZHMgWzMgMCBSXS9Db3VudCAxPj4KZW5kb2JqCjMgMCBvYmoK

--- a/src/main/kotlin/no/nav/lydia/integrasjoner/ssb/NæringsDownloader.kt
+++ b/src/main/kotlin/no/nav/lydia/integrasjoner/ssb/NæringsDownloader.kt
@@ -1,8 +1,11 @@
 package no.nav.lydia.integrasjoner.ssb
 
-import com.github.kittinunf.fuel.httpGet
 import com.google.gson.GsonBuilder
 import com.google.gson.stream.JsonReader
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.client.statement.readRawBytes
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -13,6 +16,7 @@ class NæringsDownloader(
     val næringsRepository: NæringsRepository,
 ) {
     private val log = LoggerFactory.getLogger(this.javaClass)
+    private val httpClient = HttpClient(CIO)
 
     fun lastInnNæringerFraFil() {
         // denne er lastet ned fra ssb sitt api (url ligger i nais.yaml)
@@ -32,32 +36,30 @@ class NæringsDownloader(
         }
     }
 
-    fun lastNedNæringer() {
+    suspend fun lastNedNæringer() {
         val start = System.currentTimeMillis()
         log.info("Starter å importere næringer fra ssb")
-        url.httpGet()
-            .response().third
-            .fold(success = { bytes ->
-                val gson = GsonBuilder().serializeNulls().create()
-
-                try {
-                    JsonReader(InputStreamReader(ByteArrayInputStream(bytes))).use { reader ->
-                        reader.beginObject()
-                        while (reader.hasNext() && !reader.nextName().equals("classificationItems")) {
-                            reader.skipValue()
-                        }
-                        reader.beginArray()
-                        while (reader.hasNext()) {
-                            val næringsDto = gson.fromJson<NæringsDto>(reader, NæringsDto::class.java)
-                            næringsRepository.settInn(næringsDto)
-                        }
-                        log.info("Ferdig med å importere næringer fra ssb etter ${System.currentTimeMillis() - start}ms")
+        try {
+            val bytes = httpClient.get(url).readRawBytes()
+            val gson = GsonBuilder().serializeNulls().create()
+            try {
+                JsonReader(InputStreamReader(ByteArrayInputStream(bytes))).use { reader ->
+                    reader.beginObject()
+                    while (reader.hasNext() && !reader.nextName().equals("classificationItems")) {
+                        reader.skipValue()
                     }
-                } catch (e: Exception) {
-                    log.error("Noe gikk galt under nedlasting av næringer", e)
+                    reader.beginArray()
+                    while (reader.hasNext()) {
+                        val næringsDto = gson.fromJson<NæringsDto>(reader, NæringsDto::class.java)
+                        næringsRepository.settInn(næringsDto)
+                    }
+                    log.info("Ferdig med å importere næringer fra ssb etter ${System.currentTimeMillis() - start}ms")
                 }
-            }, failure = {
-                log.error("Feil ved nedlastning av næringer (${it.message})", it.exception)
-            })
+            } catch (e: Exception) {
+                log.error("Noe gikk galt under nedlasting av næringer", e)
+            }
+        } catch (e: Exception) {
+            log.error("Feil ved nedlastning av næringer (${e.message})", e)
+        }
     }
 }

--- a/src/main/kotlin/no/nav/lydia/tilgangskontroll/Utvidelser.kt
+++ b/src/main/kotlin/no/nav/lydia/tilgangskontroll/Utvidelser.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.flatMap
 import arrow.core.left
 import arrow.core.right
+import arrow.core.raise.either
 import io.ktor.server.application.ApplicationCall
 import no.nav.lydia.ADGrupper
 import no.nav.lydia.felles.Feil
@@ -56,24 +57,22 @@ fun <T> ApplicationCall.somHøyestTilgang(
     }
 }
 
-fun <T> ApplicationCall.somSaksbehandlerMedNavenhet(
+suspend fun <T> ApplicationCall.somSaksbehandlerMedNavenhet(
     adGrupper: ADGrupper,
     azureService: AzureService,
     block: (NavAnsattMedSaksbehandlerRolle, NavEnhet) -> Either<Feil, T>,
-): Either<Feil, T> =
-    somSaksbehandler(adGrupper = adGrupper) { saksbehandler ->
-        azureService.hentNavenhet(objectId()).flatMap { navEnhet ->
-            block(saksbehandler, navEnhet)
-        }
-    }
+): Either<Feil, T> = either {
+    val saksbehandler = navAnsattMedSaksbehandlerRolle(adGrupper).bind()
+    val navEnhet = azureService.hentNavenhet(objectId()).bind()
+    block(saksbehandler, navEnhet).bind()
+}
 
-fun <T> ApplicationCall.somSuperbrukerMedNavenhet(
+suspend fun <T> ApplicationCall.somSuperbrukerMedNavenhet(
     adGrupper: ADGrupper,
     azureService: AzureService,
     block: (Superbruker, NavEnhet) -> Either<Feil, T>,
-): Either<Feil, T> =
-    somSuperbruker(adGrupper = adGrupper) { superbruker ->
-        azureService.hentNavenhet(objectId()).flatMap { navEnhet ->
-            block(superbruker, navEnhet)
-        }
-    }
+): Either<Feil, T> = either {
+    val superbruker = superbruker(adGrupper).bind()
+    val navEnhet = azureService.hentNavenhet(objectId()).bind()
+    block(superbruker, navEnhet).bind()
+}

--- a/src/main/kotlin/no/nav/lydia/tilgangskontroll/Utvidelser.kt
+++ b/src/main/kotlin/no/nav/lydia/tilgangskontroll/Utvidelser.kt
@@ -3,8 +3,8 @@ package no.nav.lydia.tilgangskontroll
 import arrow.core.Either
 import arrow.core.flatMap
 import arrow.core.left
-import arrow.core.right
 import arrow.core.raise.either
+import arrow.core.right
 import io.ktor.server.application.ApplicationCall
 import no.nav.lydia.ADGrupper
 import no.nav.lydia.felles.Feil
@@ -38,11 +38,6 @@ fun ApplicationCall.superbruker(adGrupper: ADGrupper) =
         }
     }
 
-fun <T> ApplicationCall.somSuperbruker(
-    adGrupper: ADGrupper,
-    block: (Superbruker) -> Either<Feil, T>,
-) = superbruker(adGrupper).flatMap { block(it) }
-
 fun <T> ApplicationCall.somHøyestTilgang(
     adGrupper: ADGrupper,
     block: (NavAnsatt) -> Either<Feil, T>,
@@ -61,18 +56,20 @@ suspend fun <T> ApplicationCall.somSaksbehandlerMedNavenhet(
     adGrupper: ADGrupper,
     azureService: AzureService,
     block: (NavAnsattMedSaksbehandlerRolle, NavEnhet) -> Either<Feil, T>,
-): Either<Feil, T> = either {
-    val saksbehandler = navAnsattMedSaksbehandlerRolle(adGrupper).bind()
-    val navEnhet = azureService.hentNavenhet(objectId()).bind()
-    block(saksbehandler, navEnhet).bind()
-}
+): Either<Feil, T> =
+    either {
+        val saksbehandler = navAnsattMedSaksbehandlerRolle(adGrupper).bind()
+        val navEnhet = azureService.hentNavenhet(objectId()).bind()
+        block(saksbehandler, navEnhet).bind()
+    }
 
 suspend fun <T> ApplicationCall.somSuperbrukerMedNavenhet(
     adGrupper: ADGrupper,
     azureService: AzureService,
     block: (Superbruker, NavEnhet) -> Either<Feil, T>,
-): Either<Feil, T> = either {
-    val superbruker = superbruker(adGrupper).bind()
-    val navEnhet = azureService.hentNavenhet(objectId()).bind()
-    block(superbruker, navEnhet).bind()
-}
+): Either<Feil, T> =
+    either {
+        val superbruker = superbruker(adGrupper).bind()
+        val navEnhet = azureService.hentNavenhet(objectId()).bind()
+        block(superbruker, navEnhet).bind()
+    }

--- a/src/main/kotlin/no/nav/lydia/tilgangskontroll/obo/OboTokenUtveksler.kt
+++ b/src/main/kotlin/no/nav/lydia/tilgangskontroll/obo/OboTokenUtveksler.kt
@@ -3,7 +3,12 @@ package no.nav.lydia.tilgangskontroll.obo
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
-import com.github.kittinunf.fuel.httpPost
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.http.parameters
 import kotlinx.serialization.json.Json
 import no.nav.lydia.NaisEnvironment
 import no.nav.lydia.felles.Feil
@@ -24,9 +29,11 @@ class OboTokenUtveksler(
         ignoreUnknownKeys = true
     }
 
+    private val httpClient = HttpClient(CIO)
+
     private val cache = mutableMapOf<String, TokenResponse>()
 
-    fun hentOboTokenForScope(
+    suspend fun hentOboTokenForScope(
         accessToken: String,
         scope: String,
     ): Either<Feil, TokenResponse> {
@@ -41,27 +48,27 @@ class OboTokenUtveksler(
         }
     }
 
-    private fun veksleTokenTil(
+    private suspend fun veksleTokenTil(
         accessToken: String,
         scope: String,
-    ) = azureTokenEndpoint.httpPost(
-        listOf(
-            "grant_type" to "urn:ietf:params:oauth:grant-type:jwt-bearer",
-            "client_id" to azureAppClientId,
-            "client_secret" to azureAppClientSecret,
-            "assertion" to accessToken,
-            "scope" to scope,
-            "requested_token_use" to "on_behalf_of",
-        ),
-    ).response().third.fold(
-        success = {
-            json.decodeFromString<TokenResponse>(
-                it.toString(charset = Charsets.UTF_8),
-            ).right()
-        },
-        failure = {
-            log.error("Feil ved veksling av token til $scope: ${it.message}")
+    ): Either<Feil, TokenResponse> {
+        val response = httpClient.submitForm(
+            url = azureTokenEndpoint,
+            formParameters = parameters {
+                append("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
+                append("client_id", azureAppClientId)
+                append("client_secret", azureAppClientSecret)
+                append("assertion", accessToken)
+                append("scope", scope)
+                append("requested_token_use", "on_behalf_of")
+            },
+        )
+        val body = response.bodyAsText()
+        return if (response.status.isSuccess()) {
+            json.decodeFromString<TokenResponse>(body).right()
+        } else {
+            log.error("Feil ved veksling av token til $scope: ${response.status}")
             TilgangskontrollFeil.KunneIkkeVeksleToken.left()
-        },
-    )
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/lydia/container/AppContainerTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/AppContainerTest.kt
@@ -1,11 +1,11 @@
 package no.nav.lydia.container
 
-import com.github.kittinunf.fuel.core.isSuccessful
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.string.shouldContain
 import no.nav.lydia.helper.TestContainerHelper.Companion.applikasjon
 import no.nav.lydia.helper.TestContainerHelper.Companion.performGet
 import no.nav.lydia.helper.TestContainerHelper.Companion.postgresContainerHelper
+import no.nav.lydia.helper.responseString
 import kotlin.test.Test
 import kotlin.test.fail
 

--- a/src/test/kotlin/no/nav/lydia/container/arbeidsgiver/SamarbeidApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/arbeidsgiver/SamarbeidApiTest.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.container.arbeidsgiver
 
-import com.github.kittinunf.fuel.core.extensions.authentication
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.ints.shouldBeExactly
@@ -21,6 +20,7 @@ import no.nav.lydia.helper.TestContainerHelper.Companion.performGet
 import no.nav.lydia.helper.VirksomhetHelper
 import no.nav.lydia.helper.forExactlyOne
 import no.nav.lydia.helper.hentAlleSamarbeid
+import no.nav.lydia.helper.responseString
 import no.nav.lydia.helper.statuskode
 import no.nav.lydia.helper.tilListeRespons
 import no.nav.lydia.kartlegging.Spørreundersøkelse
@@ -32,7 +32,7 @@ import kotlin.test.fail
 class SamarbeidApiTest {
     @Test
     fun `skal få feilmelding 401 dersom man ikke er innlogget`() {
-        val respons = TestContainerHelper.applikasjon.performGet("$ARBEIDSGIVER_SAMARBEID_PATH/987654321").response()
+        val respons = TestContainerHelper.applikasjon.performGet("$ARBEIDSGIVER_SAMARBEID_PATH/987654321").responseString()
         respons.second.statusCode shouldBeExactly 401
     }
 

--- a/src/test/kotlin/no/nav/lydia/container/audit/AuditLogTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/audit/AuditLogTest.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.container.audit
 
-import com.github.kittinunf.fuel.core.Request
 import io.ktor.http.HttpStatusCode
 import no.nav.lydia.AuditType
 import no.nav.lydia.Tillat
@@ -14,6 +13,7 @@ import no.nav.lydia.helper.StatistikkHelper
 import no.nav.lydia.helper.TestContainerHelper.Companion.applikasjon
 import no.nav.lydia.helper.TestContainerHelper.Companion.authContainerHelper
 import no.nav.lydia.helper.TestContainerHelper.Companion.shouldContainLog
+import no.nav.lydia.helper.TestHttpClientRequestInfo
 import no.nav.lydia.helper.TestVirksomhet
 import no.nav.lydia.helper.VirksomhetHelper
 import no.nav.lydia.helper.VirksomhetHelper.Companion.lastInnNyVirksomhet
@@ -266,7 +266,7 @@ class AuditLogTest {
     }
 
     private fun auditLog(
-        request: Request,
+        request: TestHttpClientRequestInfo,
         navIdent: String,
         orgnummer: String? = null,
         auditType: AuditType,

--- a/src/test/kotlin/no/nav/lydia/container/ia/eksport/SamarbeidsplanBigqueryEksportererTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/eksport/SamarbeidsplanBigqueryEksportererTest.kt
@@ -13,9 +13,10 @@ import no.nav.lydia.helper.PlanHelper.Companion.endreStatusPåInnholdIPlan
 import no.nav.lydia.helper.PlanHelper.Companion.hentPlanMal
 import no.nav.lydia.helper.PlanHelper.Companion.inkluderAlt
 import no.nav.lydia.helper.PlanHelper.Companion.inkluderEttTemaOgEttInnhold
-import no.nav.lydia.helper.PlanHelper.Companion.opprettEnPlan
+import no.nav.lydia.helper.PlanHelper.Companion.opprettSamarbeidsplan
 import no.nav.lydia.helper.PlanHelper.Companion.tilRequest
 import no.nav.lydia.helper.TestContainerHelper.Companion.kafkaContainerHelper
+import no.nav.lydia.helper.hentAlleSamarbeid
 import no.nav.lydia.samarbeidsplan.PlanMalDto
 import no.nav.lydia.samarbeidsplan.PlanUndertema
 import no.nav.lydia.samarbeidsplan.SamarbeidsplanBigqueryProdusent.InnholdIPlanMelding
@@ -48,8 +49,11 @@ class SamarbeidsplanBigqueryEksportererTest {
     @Test
     fun `oppretting av plan skal trigge kafka-eksport til BigQuery`() {
         val sak = aktivSamarbeidsperiode()
-        val planMalDto: PlanMalDto = hentPlanMal()
-        val plan = sak.opprettEnPlan(plan = planMalDto.inkluderAlt())
+        val samarbeid = sak.hentAlleSamarbeid().first()
+        val plan = samarbeid.opprettSamarbeidsplan(
+            orgnr = sak.orgnr,
+            planMal = PlanMalDto().inkluderAlt(),
+        )
 
         runBlocking {
             kafkaContainerHelper.ventOgKonsumerKafkaMeldinger(
@@ -69,8 +73,12 @@ class SamarbeidsplanBigqueryEksportererTest {
     @Test
     fun `endring av hele planen skal trigge kafka-eksport til BigQuery`() {
         val sak = aktivSamarbeidsperiode()
+        val samarbeid = sak.hentAlleSamarbeid().first()
         val enTomPlan: PlanMalDto = hentPlanMal()
-        val plan = sak.opprettEnPlan(plan = enTomPlan)
+        val plan = samarbeid.opprettSamarbeidsplan(
+            orgnr = sak.orgnr,
+            planMal = enTomPlan,
+        )
         val planMedAlt = plan.inkluderAlt()
 
         sak.endreFlereTemaerIPlan(
@@ -96,9 +104,11 @@ class SamarbeidsplanBigqueryEksportererTest {
     @Test
     fun `endring av tema skal trigge kafka-eksport til BigQuery`() {
         val sak = aktivSamarbeidsperiode()
+        val samarbeid = sak.hentAlleSamarbeid().first()
         val enTomPlan: PlanMalDto = hentPlanMal()
-        val plan = sak.opprettEnPlan(
-            plan = enTomPlan.inkluderEttTemaOgEttInnhold(
+        val plan = samarbeid.opprettSamarbeidsplan(
+            orgnr = sak.orgnr,
+            planMal = enTomPlan.inkluderEttTemaOgEttInnhold(
                 temanummer = 3,
                 innholdnummer = 1,
             ),
@@ -128,8 +138,12 @@ class SamarbeidsplanBigqueryEksportererTest {
     @Test
     fun `endret status på innhold skal trigge kafka-eksport til BigQuery`() {
         val sak = aktivSamarbeidsperiode()
+        val samarbeid = sak.hentAlleSamarbeid().first()
         val enPlanMedAltMed: PlanMalDto = hentPlanMal().inkluderAlt()
-        val plan = sak.opprettEnPlan(plan = enPlanMedAltMed)
+        val plan = samarbeid.opprettSamarbeidsplan(
+            orgnr = sak.orgnr,
+            planMal = enPlanMedAltMed,
+        )
 
         val sisteTema = plan.temaer.last()
         val sisteInnhold = sisteTema.undertemaer.last()

--- a/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/BehovsvurderingApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/BehovsvurderingApiTest.kt
@@ -526,7 +526,7 @@ class BehovsvurderingApiTest {
         val behovsvurdering = sak.opprettBehovsvurdering()
         behovsvurdering.status shouldBe Spørreundersøkelse.Status.OPPRETTET
 
-        shouldFailWithMessage("HTTP Exception 403 Forbidden") {
+        shouldFailWithMessage("HTTP 403 Forbidden: Spørreundersøkelse er ikke i status 'PÅBEGYNT', kan ikke avslutte") {
             behovsvurdering.fullfør(orgnummer = sak.orgnr, saksnummer = sak.saksnummer)
         }
     }

--- a/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/EvalueringApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/sak/kartlegging/EvalueringApiTest.kt
@@ -250,7 +250,7 @@ class EvalueringApiTest {
     fun `skal ikke kunne opprette en tom evaluering pga tom plan`() {
         val sak = aktivSamarbeidsperiode()
         sak.opprettEnPlan(plan = hentPlanMal())
-        shouldFail { sak.opprettEvaluering() }.message shouldBe "HTTP Exception 400 Bad Request"
+        shouldFail { sak.opprettEvaluering() }.message shouldBe "HTTP 400 Bad Request: Kan ikke opprette en evaluering basert på en tom plan"
     }
 
     @Test

--- a/src/test/kotlin/no/nav/lydia/container/ia/sak/plan/PlanApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/sak/plan/PlanApiTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldStartWith
 import io.ktor.http.HttpStatusCode
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DateTimeUnit
@@ -70,7 +71,7 @@ class PlanApiTest {
         val slettetPlan = samarbeid.slettSamarbeidsplan(orgnr = sak.orgnr, plan.id)
         slettetPlan.status shouldBe IASamarbeid.Status.SLETTET
 
-        shouldFailWithMessage("HTTP Exception 404 Not Found") {
+        shouldFailWithMessage("HTTP 404 Not Found: Fant ikke plan") {
             sak.hentPlan(prosessId = samarbeid.id)
         }
     }
@@ -102,7 +103,7 @@ class PlanApiTest {
             }
         }
 
-        shouldFailWithMessage("HTTP Exception 404 Not Found") {
+        shouldFailWithMessage("HTTP 404 Not Found: Fant ikke plan") {
             sak.hentPlan(prosessId = samarbeid.id)
         }
     }
@@ -132,7 +133,7 @@ class PlanApiTest {
             melding = Json.encodeToString(salesforceAktivitet),
             topic = Topic.SALESFORCE_AKTIVITET_TOPIC,
         )
-        shouldFailWithMessage("HTTP Exception 409 Conflict") {
+        shouldFailWithMessage("HTTP 409 Conflict: Det finnes aktiviteter registrert på dette undertemaet i Salesforce.") {
             sak.endreEttTemaIPlan(
                 planId = plan.id,
                 temaId = førsteTema.id,
@@ -214,14 +215,14 @@ class PlanApiTest {
                 planId = planDto.id,
                 endring = datoUtenInkludert.tilRequest(),
             )
-        }.message shouldBe "HTTP Exception 400 Bad Request"
+        }.message shouldStartWith "HTTP 400 Bad Request"
 
         shouldFail {
             sak.endreFlereTemaerIPlan(
                 planId = planDto.id,
                 endring = inkludertUtenDato.tilRequest(),
             )
-        }.message shouldBe "HTTP Exception 400 Bad Request"
+        }.message shouldStartWith "HTTP 400 Bad Request"
 
         val uendretPlan = sak.hentPlan()
         uendretPlan.antallTemaInkludert() shouldBe 0
@@ -242,7 +243,7 @@ class PlanApiTest {
                 endring = datoUtenInkludert.temaer.first().undertemaer.tilRequest(),
                 temaId = planDto.temaer.first().id,
             )
-        }.message shouldBe "HTTP Exception 400 Bad Request"
+        }.message shouldStartWith "HTTP 400 Bad Request"
 
         shouldFail {
             sak.endreEttTemaIPlan(
@@ -250,7 +251,7 @@ class PlanApiTest {
                 endring = inkludertUtenDato.temaer.first().undertemaer.tilRequest(),
                 temaId = planDto.temaer.first().id,
             )
-        }.message shouldBe "HTTP Exception 400 Bad Request"
+        }.message shouldStartWith "HTTP 400 Bad Request"
 
         val sammePlan = sak.hentPlan()
         sammePlan.antallTemaInkludert() shouldBe 1
@@ -417,7 +418,7 @@ class PlanApiTest {
                 innholdId = plan.temaer.first().undertemaer.first().id,
                 status = PlanUndertema.Status.FULLFØRT,
             )
-        }.message shouldBe "HTTP Exception 400 Bad Request"
+        }.message shouldStartWith "HTTP 400 Bad Request"
 
         val endretPlan = sak.hentPlan()
         endretPlan.antallTemaInkludert() shouldBe 0
@@ -463,7 +464,7 @@ class PlanApiTest {
                 temaId = førsteTema.id,
                 endring = endring,
             )
-        }.message shouldBe "HTTP Exception 400 Bad Request"
+        }.message shouldStartWith "HTTP 400 Bad Request"
 
         val endretPlan = sak.hentPlan()
         endretPlan.antallTemaInkludert() shouldBe 0
@@ -490,7 +491,7 @@ class PlanApiTest {
                 temaId = endring.temaer.first().id,
                 endring = endring.tilRequest().first().undertemaer,
             )
-        }.message shouldBe "HTTP Exception 400 Bad Request"
+        }.message shouldStartWith "HTTP 400 Bad Request"
 
         val endretPlan = sak.hentPlan()
         endretPlan.antallTemaInkludert() shouldBe 0
@@ -696,7 +697,7 @@ class PlanApiTest {
                 innholdId = førsteUndertema.id,
                 status = PlanUndertema.Status.AVBRUTT,
             )
-        }.message shouldBe "HTTP Exception 400 Bad Request"
+        }.message shouldStartWith "HTTP 400 Bad Request"
     }
 
     @Test
@@ -719,7 +720,7 @@ class PlanApiTest {
                 innholdId = opprettetPlan.temaer.first().undertemaer.first().id,
                 status = nyStatus,
             )
-        }.message shouldBe "HTTP Exception 400 Bad Request"
+        }.message shouldStartWith "HTTP 400 Bad Request"
 
         sak.endreStatusPåInnholdIPlan(
             planId = opprettetPlan.id,
@@ -760,7 +761,7 @@ class PlanApiTest {
         val gyldigPlan = enTomPlan.inkluderEttTemaOgAltInnhold(temanummer = 3)
 
         shouldFail { sak.opprettEnPlan(plan = ugyldigPlan) }
-            .message shouldBe "HTTP Exception 400 Bad Request"
+            .message shouldBe "HTTP 400 Bad Request: Feil inndata i forespørsel"
 
         val opprettetPlan = sak.opprettEnPlan(plan = gyldigPlan)
         val sisteTema = opprettetPlan.temaer.last()
@@ -790,7 +791,7 @@ class PlanApiTest {
                 planId = opprettetPlan.id,
                 endring = ugyldigEndring.tilRequest(),
             )
-        }.message shouldBe "HTTP Exception 400 Bad Request"
+        }.message shouldStartWith "HTTP 400 Bad Request"
 
         val uendretPlan = sak.hentPlan()
 
@@ -832,7 +833,7 @@ class PlanApiTest {
                 endring = nyUgyldigEndring.tilRequest().last().undertemaer,
                 temaId = nyUgyldigEndring.temaer.last().id,
             )
-        }.message shouldBe "HTTP Exception 400 Bad Request"
+        }.message shouldStartWith "HTTP 400 Bad Request"
 
         sak.endreEttTemaIPlan(
             planId = endretPlan.id,
@@ -855,7 +856,7 @@ class PlanApiTest {
     @Test
     fun `skal få feil når man henter plan uten å ha opprettet en plan`() {
         val sak = aktivSamarbeidsperiode()
-        shouldFail { sak.hentPlan() }.message shouldBe "HTTP Exception 404 Not Found"
+        shouldFail { sak.hentPlan() }.message shouldStartWith "HTTP 404 Not Found: Fant ikke plan"
     }
 
     @Test
@@ -898,7 +899,7 @@ class PlanApiTest {
         val slettetPlan = samarbeid.slettSamarbeidsplan(orgnr = sak.orgnr, planId = plan.id)
         slettetPlan.status shouldBe IASamarbeid.Status.SLETTET
 
-        shouldFailWithMessage("HTTP Exception 404 Not Found") {
+        shouldFailWithMessage("HTTP 404 Not Found: Fant ikke plan") {
             sak.hentPlan(token = følgerAvSak.token, prosessId = samarbeid.id)
         }
     }

--- a/src/test/kotlin/no/nav/lydia/container/ia/sak/prosess/IASakProsessTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/sak/prosess/IASakProsessTest.kt
@@ -124,7 +124,7 @@ class IASakProsessTest {
         val samarbeid = sak.opprettSamarbeid()
         sak.opprettBehovsvurdering()
 
-        shouldFailWithMessage("HTTP Exception 400 Bad Request") {
+        shouldFailWithMessage("HTTP 400 Bad Request: kan ikke avbryte samarbeid") {
             samarbeid.avsluttSamarbeid(orgnr = sak.orgnr, avslutningsType = IASamarbeid.Status.AVBRUTT)
         }
     }
@@ -553,8 +553,8 @@ class IASakProsessTest {
     fun `skal kun kunne opprette samarbeid med unikt navn`() {
         val sak = vurderVirksomhet().leggTilFolger(authContainerHelper.saksbehandler1.token)
         sak.opprettSamarbeid(samarbeidsnavn = "Navn")
-        shouldFail { sak.opprettSamarbeid(samarbeidsnavn = "Navn") }.message shouldBe "HTTP Exception 409 Conflict"
-        shouldFail { sak.opprettSamarbeid(samarbeidsnavn = "Navn") }.message shouldBe "HTTP Exception 409 Conflict"
+        shouldFail { sak.opprettSamarbeid(samarbeidsnavn = "Navn") }.message shouldBe "HTTP 409 Conflict: Samarbeidsnavn finnes allerede"
+        shouldFail { sak.opprettSamarbeid(samarbeidsnavn = "Navn") }.message shouldBe "HTTP 409 Conflict: Samarbeidsnavn finnes allerede"
 
         sak.hentAlleSamarbeid().count { it.navn == "Navn" } shouldBeExactly 1
     }

--- a/src/test/kotlin/no/nav/lydia/container/ia/team/IASakTeamApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ia/team/IASakTeamApiTest.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.container.ia.team
 
-import com.github.kittinunf.fuel.core.extensions.authentication
 import io.kotest.matchers.collections.shouldBeUnique
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldHaveSize

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
@@ -1,7 +1,5 @@
 package no.nav.lydia.container.ny.flyt
 
-import com.github.kittinunf.fuel.core.extensions.authentication
-import com.github.kittinunf.fuel.core.extensions.jsonBody
 import ia.felles.definisjoner.bransjer.Bransje
 import ia.felles.definisjoner.bransjer.BransjeId
 import ia.felles.integrasjoner.jobbsender.Jobb
@@ -1059,7 +1057,7 @@ class NyFlytTest {
 
         shouldFail {
             samarbeid.slettSamarbeid(orgnr = sak.orgnr, token = authContainerHelper.saksbehandler1.token)
-        }.message shouldMatch ("HTTP Exception 400 Bad Request")
+        }.message shouldMatch ("HTTP 400 Bad Request: kan ikke slette samarbeid som inneholder behovsvurdering eller samarbeidsplan")
 
         hentVirksomhetTilstand(sak.orgnr).tilstand shouldBe VirksomhetIATilstand.VirksomhetHarAktiveSamarbeid
     }

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -1,7 +1,5 @@
 package no.nav.lydia.container.ny.flyt
 
-import com.github.kittinunf.fuel.core.extensions.authentication
-import com.github.kittinunf.fuel.core.extensions.jsonBody
 import io.kotest.inspectors.forAll
 import io.kotest.inspectors.forAtLeastOne
 import io.kotest.inspectors.shouldForAll

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/kartlegging/NyFlytKartleggingTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/kartlegging/NyFlytKartleggingTest.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.container.ny.flyt.kartlegging
 
-import com.github.kittinunf.fuel.core.extensions.authentication
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpStatusCode
 import no.nav.lydia.api.NY_FLYT_API_PATH

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/plan/NyFlytSamarbeidsplanTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/plan/NyFlytSamarbeidsplanTest.kt
@@ -170,7 +170,7 @@ class NyFlytSamarbeidsplanTest {
             nySluttDato = null,
         ).tilRequest()
 
-        shouldFailWithMessage("HTTP Exception 409 Conflict") {
+        shouldFailWithMessage("HTTP 409 Conflict: Det finnes aktiviteter registrert på dette undertemaet i Salesforce.") {
             val plan = samarbeid.oppdaterSamarbeidsplan(
                 orgnr = sak.orgnr,
                 planId = opprinneligPlan.id,
@@ -276,7 +276,7 @@ class NyFlytSamarbeidsplanTest {
         val førsteTema = plan.temaer.first()
         val førsteUndertema = førsteTema.undertemaer.first()
 
-        shouldFailWithMessage("HTTP Exception 400 Bad Request") {
+        shouldFailWithMessage("HTTP 400 Bad Request: Kan ikke endre status på innhold som ikke er inkludert") {
             samarbeid.endreStatusPåUndertemaISamarbeidsplan(
                 orgnr = sak.orgnr,
                 planId = plan.id,
@@ -323,7 +323,7 @@ class NyFlytSamarbeidsplanTest {
         førsteUndertema.status shouldBe PlanUndertema.Status.PLANLAGT
         førsteUndertema.startDato shouldBe iMorgen
 
-        shouldFailWithMessage("HTTP Exception 400 Bad Request") {
+        shouldFailWithMessage("HTTP 400 Bad Request: Kan ikke endre status til 'AVBRUTT' om innholdet ikke har startet enda") {
             samarbeid.endreStatusPåUndertemaISamarbeidsplan(
                 orgnr = sak.orgnr,
                 planId = plan.id,

--- a/src/test/kotlin/no/nav/lydia/container/sykefraværsstatistikk/SykefraværsstatistikkApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraværsstatistikk/SykefraværsstatistikkApiTest.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.container.sykefraværsstatistikk
 
-import com.github.kittinunf.fuel.core.extensions.authentication
 import ia.felles.definisjoner.bransjer.Bransje
 import io.kotest.inspectors.forAll
 import io.kotest.inspectors.forAtLeastOne
@@ -72,6 +71,7 @@ import no.nav.lydia.helper.VirksomhetHelper.Companion.hentVirksomhetsinformasjon
 import no.nav.lydia.helper.VirksomhetHelper.Companion.lastInnNyVirksomhet
 import no.nav.lydia.helper.VirksomhetHelper.Companion.nyttOrgnummer
 import no.nav.lydia.helper.forExactlyOne
+import no.nav.lydia.helper.responseString
 import no.nav.lydia.helper.statuskode
 import no.nav.lydia.helper.tilSingelRespons
 import no.nav.lydia.prioritering.sykefraværsstatistikk.LANDKODE_NO
@@ -247,7 +247,7 @@ class SykefraværsstatistikkApiTest {
 
         val results = hentSykefravær(
             snittFilter = SnittFilter.BRANSJE_NÆRING_UNDER_ELLER_LIK.name,
-            næringsgrupper = listOf(NÆRING_JORDBRUK, NÆRING_SKOGBRUK).joinToString { "," },
+            næringsgrupper = listOf(NÆRING_JORDBRUK, NÆRING_SKOGBRUK).joinToString(separator = ","),
         ).data
 
         results.size shouldBeGreaterThanOrEqual 2
@@ -300,7 +300,7 @@ class SykefraværsstatistikkApiTest {
 
         val results = hentSykefravær(
             snittFilter = SnittFilter.BRANSJE_NÆRING_OVER.name,
-            næringsgrupper = listOf(NÆRING_JORDBRUK, NÆRING_SKOGBRUK).joinToString { "," },
+            næringsgrupper = listOf(NÆRING_JORDBRUK, NÆRING_SKOGBRUK).joinToString(separator = ","),
         ).data
 
         results.size shouldBeGreaterThanOrEqual 2

--- a/src/test/kotlin/no/nav/lydia/container/sykefraværsstatistikk/SykefraværsstatistikkVirksomhetApiTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/sykefraværsstatistikk/SykefraværsstatistikkVirksomhetApiTest.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.container.sykefraværsstatistikk
 
-import com.github.kittinunf.fuel.core.extensions.authentication
 import ia.felles.definisjoner.bransjer.Bransje.TRANSPORT
 import io.kotest.matchers.shouldBe
 import no.nav.lydia.Topic

--- a/src/test/kotlin/no/nav/lydia/helper/DokumentPubliseringHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/DokumentPubliseringHelper.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.helper
 
-import com.github.kittinunf.fuel.core.extensions.authentication
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.toKotlinLocalDateTime
 import kotlinx.serialization.json.Json

--- a/src/test/kotlin/no/nav/lydia/helper/IAProsessHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/IAProsessHelper.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.helper
 
-import com.github.kittinunf.fuel.core.extensions.authentication
 import no.nav.lydia.api.IA_SAK_RADGIVER_PATH
 import no.nav.lydia.helper.TestContainerHelper.Companion.applikasjon
 import no.nav.lydia.helper.TestContainerHelper.Companion.authContainerHelper

--- a/src/test/kotlin/no/nav/lydia/helper/IASakSpørreundersøkelseHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/IASakSpørreundersøkelseHelper.kt
@@ -1,7 +1,7 @@
 package no.nav.lydia.helper
 
-import com.github.kittinunf.fuel.core.extensions.authentication
 import io.kotest.matchers.collections.shouldHaveSize
+import kotlinx.serialization.builtins.ByteArraySerializer
 import kotlinx.serialization.json.Json
 import no.nav.lydia.Topic
 import no.nav.lydia.api.NY_FLYT_API_PATH
@@ -50,12 +50,13 @@ class IASakSpørreundersøkelseHelper {
             orgnr: String,
             saksnummer: String,
             token: String = TestContainerHelper.authContainerHelper.saksbehandler1.token,
-        ) = TestContainerHelper.applikasjon.performGet("${SPØRREUNDERSØKELSE_BASE_ROUTE}/$orgnr/$saksnummer/$id/pdf")
-            .authentication().bearer(token)
-            .response().third.fold(
-                success = { it },
-                failure = { fail(it.message) },
-            )
+        ): ByteArray =
+            TestContainerHelper.applikasjon.performGet("${SPØRREUNDERSØKELSE_BASE_ROUTE}/$orgnr/$saksnummer/$id/pdf")
+                .authentication().bearer(token)
+                .responseByteArray().third.fold(
+                    success = { it },
+                    failure = { fail(it.message) },
+                )
 
         fun hentSpørreundersøkelse(
             orgnr: String,

--- a/src/test/kotlin/no/nav/lydia/helper/PlanHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/PlanHelper.kt
@@ -1,7 +1,5 @@
 package no.nav.lydia.helper
 
-import com.github.kittinunf.fuel.core.extensions.authentication
-import com.github.kittinunf.fuel.core.extensions.jsonBody
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.json.Json
 import no.nav.lydia.api.NY_FLYT_API_PATH
@@ -233,6 +231,7 @@ class PlanHelper {
             )
 
         // TODO: [OPPRYDDING] Bør gå bort ifra denne måten å opprette planer
+        @Deprecated("Bruk IASamarbeidDto.opprettSamarbeidsplan i stedet")
         fun IASakDto.opprettEnPlan(
             token: String = TestContainerHelper.authContainerHelper.saksbehandler1.token,
             plan: PlanMalDto = hentPlanMal().inkluderAlt(),

--- a/src/test/kotlin/no/nav/lydia/helper/SakHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/SakHelper.kt
@@ -1,8 +1,5 @@
 package no.nav.lydia.helper
 
-import com.github.kittinunf.fuel.core.ResponseResultOf
-import com.github.kittinunf.fuel.core.extensions.authentication
-import com.github.kittinunf.fuel.serialization.responseObject
 import io.kotest.matchers.shouldBe
 import no.nav.lydia.api.IA_SAK_LEVERANSE_PATH
 import no.nav.lydia.api.IA_SAK_RADGIVER_PATH
@@ -100,7 +97,7 @@ class SakHelper {
         fun hentSamarbeidshistorikkNyFlytRespons(
             orgnummer: String,
             token: String = TestContainerHelper.authContainerHelper.saksbehandler1.token,
-        ): ResponseResultOf<List<SakshistorikkDto>> {
+        ): TestResponseTriple<List<SakshistorikkDto>> {
             val url = "${NY_FLYT_PATH}/virksomhet/$orgnummer/historikk"
             return TestContainerHelper.applikasjon.performGet(url)
                 .authentication().bearer(token = token)

--- a/src/test/kotlin/no/nav/lydia/helper/StatistikkHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/StatistikkHelper.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.helper
 
-import com.github.kittinunf.fuel.core.extensions.authentication
 import no.nav.lydia.api.ANTALL_TREFF
 import no.nav.lydia.api.FILTERVERDIER_PATH
 import no.nav.lydia.api.HISTORISK_STATISTIKK

--- a/src/test/kotlin/no/nav/lydia/helper/StatusoversiktHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/StatusoversiktHelper.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.helper
 
-import com.github.kittinunf.fuel.core.extensions.authentication
 import no.nav.lydia.api.STATUSOVERSIKT_PATH
 import no.nav.lydia.helper.TestContainerHelper.Companion.performGet
 import no.nav.lydia.prioritering.sykefraværsstatistikk.api.Søkeparametere

--- a/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
@@ -1,18 +1,9 @@
 package no.nav.lydia.helper
 
-import com.github.kittinunf.fuel.core.Request
-import com.github.kittinunf.fuel.httpDelete
-import com.github.kittinunf.fuel.httpGet
-import com.github.kittinunf.fuel.httpPost
-import com.github.kittinunf.fuel.httpPut
-import com.github.kittinunf.fuel.serialization.responseObject
 import ia.felles.definisjoner.bransjer.Bransje
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
-import kotlinx.serialization.InternalSerializationApi
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.serializer
+import io.ktor.http.HttpMethod
 import no.nav.lydia.Topic
 import no.nav.lydia.helper.TestData.Companion.lagPerioder
 import no.nav.lydia.integrasjoner.ssb.NæringsDownloader
@@ -169,22 +160,16 @@ class TestContainerHelper {
 
         private fun GenericContainer<*>.buildUrl(url: String) = "http://${this.host}:${this.getMappedPort(8080)}/$url"
 
-        fun GenericContainer<*>.performGet(url: String) = buildUrl(url = url).httpGet()
+        fun GenericContainer<*>.performGet(url: String) = TestRequest(HttpMethod.Get, buildUrl(url))
 
-        fun GenericContainer<*>.performPost(url: String) = buildUrl(url = url).httpPost()
+        fun GenericContainer<*>.performPost(url: String) = TestRequest(HttpMethod.Post, buildUrl(url))
 
-        fun GenericContainer<*>.performDelete(url: String) = buildUrl(url = url).httpDelete()
+        fun GenericContainer<*>.performDelete(url: String) = TestRequest(HttpMethod.Delete, buildUrl(url))
 
-        fun GenericContainer<*>.performPut(url: String) = buildUrl(url = url).httpPut()
+        fun GenericContainer<*>.performPut(url: String) = TestRequest(HttpMethod.Put, buildUrl(url))
 
         infix fun GenericContainer<*>.shouldContainLog(regex: Regex) = logs shouldContain regex
 
         infix fun GenericContainer<*>.shouldNotContainLog(regex: Regex) = logs shouldNotContain regex
     }
 }
-
-@OptIn(InternalSerializationApi::class)
-inline fun <reified T : Any> Request.tilListeRespons() = this.responseObject(loader = ListSerializer(T::class.serializer()), json = Json)
-
-@OptIn(InternalSerializationApi::class)
-inline fun <reified T : Any> Request.tilSingelRespons() = this.responseObject(loader = T::class.serializer(), json = Json)

--- a/src/test/kotlin/no/nav/lydia/helper/TestHttpClient.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestHttpClient.kt
@@ -1,0 +1,204 @@
+package no.nav.lydia.helper
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.contentType
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import java.net.URI
+import java.net.URL
+
+internal val testHttpClient = HttpClient(CIO)
+
+private val json = Json { ignoreUnknownKeys = true }
+
+internal fun String.toAsciiUrl(): String = URI(this).toASCIIString()
+
+class TestRequest(
+    private val method: HttpMethod,
+    private val url: String,
+) {
+    private var authToken: String? = null
+    private var bodyContent: String? = null
+
+    inner class AuthExtension {
+        fun bearer(token: String) = this@TestRequest.also { it.authToken = token }
+    }
+
+    fun authentication() = AuthExtension()
+
+    fun jsonBody(json: String) = apply { bodyContent = json }
+
+    internal fun executeBlocking(): Triple<Int, String, String> =
+        runBlocking {
+            val response = testHttpClient.request(url.toAsciiUrl()) {
+                this.method = this@TestRequest.method
+                authToken?.let { bearerAuth(it) }
+                bodyContent?.let {
+                    contentType(ContentType.Application.Json)
+                    setBody(it)
+                }
+            }
+            Triple(response.status.value, response.status.description, response.bodyAsText())
+        }
+
+    internal fun executeBlockingByteArray(): Triple<Int, String, ByteArray> =
+        runBlocking {
+            val response = testHttpClient.request(url.toAsciiUrl()) {
+                this.method = this@TestRequest.method
+                authToken?.let { bearerAuth(it) }
+                bodyContent?.let {
+                    contentType(ContentType.Application.Json)
+                    setBody(it)
+                }
+            }
+            Triple(response.status.value, response.status.description, response.body())
+        }
+
+    internal fun toRequestInfo() = TestHttpClientRequestInfo(methodValue = method.value, urlValue = url.toAsciiUrl())
+}
+
+data class TestHttpClientRequestInfo(
+    private val methodValue: String,
+    private val urlValue: String,
+) {
+    val method: String = methodValue
+    val url: URL = URI(urlValue).toURL()
+}
+
+class TestHttpClientBody(
+    private val text: String,
+) {
+    fun asString(contentType: String): String = text
+}
+
+class TestHttpClientResponse(
+    val statusCode: Int,
+    val statusDescription: String,
+    private val bodyText: String,
+) {
+    val isSuccessful: Boolean get() = statusCode in 200..299
+
+    fun body(): TestHttpClientBody = TestHttpClientBody(bodyText)
+}
+
+class TestHttpClientError(
+    val bodyText: String,
+    val statusCode: Int,
+    val statusDescription: String,
+    val cause: Exception? = null,
+) {
+    val message: String get() = "HTTP $statusCode $statusDescription: $bodyText"
+    val response: TestHttpClientResponse = TestHttpClientResponse(statusCode = statusCode, statusDescription = statusDescription, bodyText = bodyText)
+
+    fun stackTraceToString(): String = cause?.stackTraceToString() ?: message
+}
+
+sealed class TestResult<T> {
+    data class Success<T>(
+        val value: T,
+    ) : TestResult<T>()
+
+    data class Failure<T>(
+        val error: TestHttpClientError,
+    ) : TestResult<T>()
+
+    fun <R> fold(
+        success: (T) -> R,
+        failure: (TestHttpClientError) -> R,
+    ): R =
+        when (this) {
+            is Success -> success(value)
+            is Failure -> failure(error)
+        }
+
+    fun get(): T =
+        when (this) {
+            is Success -> value
+            is Failure -> throw error.cause ?: Exception(error.message)
+        }
+
+    override fun toString(): String =
+        when (this) {
+            is Success -> "Success($value)"
+            is Failure -> "Failure(${error.message})"
+        }
+}
+
+class TestResponseTriple<T>(
+    requestInfo: TestHttpClientRequestInfo,
+    statusCode: Int,
+    statusDescription: String,
+    bodyText: String,
+    result: TestResult<T>,
+) {
+    val first = requestInfo
+    val second = TestHttpClientResponse(statusCode = statusCode, statusDescription = statusDescription, bodyText = bodyText)
+    val third = result
+
+    operator fun component1() = first
+
+    operator fun component2() = second
+
+    operator fun component3() = third
+}
+
+fun <T : Any> TestRequest.responseObject(serializer: KSerializer<T>): TestResponseTriple<T> {
+    val (statusCode, statusDescription, body) = executeBlocking()
+    val result = if (statusCode in 200..299) {
+        try {
+            TestResult.Success(json.decodeFromString(serializer, body))
+        } catch (e: Exception) {
+            TestResult.Failure(TestHttpClientError(bodyText = body, statusCode = statusCode, statusDescription = statusDescription, cause = e))
+        }
+    } else {
+        TestResult.Failure(TestHttpClientError(bodyText = body, statusCode = statusCode, statusDescription = statusDescription))
+    }
+    return TestResponseTriple(requestInfo = toRequestInfo(), statusCode = statusCode, statusDescription = statusDescription, bodyText = body, result = result)
+}
+
+fun TestRequest.responseString(): TestResponseTriple<String> {
+    val (statusCode, statusDescription, body) = executeBlocking()
+    val result =
+        if (statusCode in 200..299) {
+            TestResult.Success(body)
+        } else {
+            TestResult.Failure(error = TestHttpClientError(bodyText = body, statusCode = statusCode, statusDescription = statusDescription))
+        }
+    return TestResponseTriple(requestInfo = toRequestInfo(), statusCode = statusCode, statusDescription = statusDescription, bodyText = body, result = result)
+}
+
+fun TestRequest.responseByteArray(): TestResponseTriple<ByteArray> {
+    val (statusCode, statusDescription, body) = executeBlockingByteArray()
+    val bodyText = body.decodeToString()
+    val result =
+        if (statusCode in 200..299) {
+            TestResult.Success(body)
+        } else {
+            TestResult.Failure(error = TestHttpClientError(bodyText = bodyText, statusCode = statusCode, statusDescription = statusDescription))
+        }
+    return TestResponseTriple(
+        requestInfo = toRequestInfo(),
+        statusCode = statusCode,
+        statusDescription = statusDescription,
+        bodyText = bodyText,
+        result = result,
+    )
+}
+
+@OptIn(InternalSerializationApi::class)
+inline fun <reified T : Any> TestRequest.tilSingelRespons() = responseObject(T::class.serializer())
+
+@OptIn(InternalSerializationApi::class)
+inline fun <reified T : Any> TestRequest.tilListeRespons() = responseObject(ListSerializer(T::class.serializer()))

--- a/src/test/kotlin/no/nav/lydia/helper/TestHttpClientTest.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestHttpClientTest.kt
@@ -1,0 +1,12 @@
+package no.nav.lydia.helper
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class TestHttpClientTest {
+    @Test
+    fun `toAsciiUrl percent-encodes non-ascii query names and values`() {
+        "http://localhost:8080/api?Søkeparametere=blåbær".toAsciiUrl() shouldBe
+            "http://localhost:8080/api?S%C3%B8keparametere=bl%C3%A5b%C3%A6r"
+    }
+}

--- a/src/test/kotlin/no/nav/lydia/helper/TestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestUtils.kt
@@ -1,10 +1,9 @@
 package no.nav.lydia.helper
 
-import com.github.kittinunf.fuel.core.ResponseResultOf
 import io.kotest.inspectors.forExactly
 
 inline fun <T, C : Collection<T>> C.forExactlyOne(fn: (T) -> Unit): C = this.forExactly(1, fn)
 
-fun <T> ResponseResultOf<T>.statuskode() = this.second.statusCode
+fun <T> TestResponseTriple<T>.statuskode() = this.second.statusCode
 
-fun <T> ResponseResultOf<T>.body(): String = this.second.body().asString(contentType = "text/plain; charset=utf-8")
+fun <T> TestResponseTriple<T>.body(): String = this.second.body().asString("text/plain; charset=utf-8")

--- a/src/test/kotlin/no/nav/lydia/helper/VirksomhetHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/VirksomhetHelper.kt
@@ -1,6 +1,5 @@
 package no.nav.lydia.helper
 
-import com.github.kittinunf.fuel.core.extensions.authentication
 import no.nav.lydia.Topic
 import no.nav.lydia.api.SALESFORCE_INFO_PATH
 import no.nav.lydia.api.VIRKSOMHET_PATH


### PR DESCRIPTION
Refactor. Erstatte Fuel HttpClient med Ktor HttpClient 
 - vi kan bruke en HttpClient som vi allerede har i Ktor
 - vi blir kvitt en avhengighet til et bibliotek som ikke er veldig aktivt vedlikeholdt (siste endringer gjelder en ny major versjon) 
 - største impakt/endringer er på test klasser 

Dette er noe vi hadde tenkt å gjøre før. Men oppgaven ble utsatt flere ganger da Fuel gjør synkrone kall og Ktor HttpClient er asynk. Nå har oppgaven blitt enklere etter vi har laget extensions i `ApplicationCall` `somSaksbehandlerMedNavenhet` + `suspend` 