### PR TITLE
Dupliser virksomhet endepunkter til ny api path

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,7 +70,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/erstatte-fuel-med-ktor-http-client'
+    if: github.ref == 'refs/heads/dupliser-virksomhet-endepunkter-til-ny-api-path'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/src/main/kotlin/no/nav/lydia/App.kt
+++ b/src/main/kotlin/no/nav/lydia/App.kt
@@ -32,6 +32,7 @@ import no.nav.lydia.api.iaSakTeam
 import no.nav.lydia.api.iaSamarbeid
 import no.nav.lydia.api.nyFlyt
 import no.nav.lydia.api.nyFlytKartlegging
+import no.nav.lydia.api.nyFlytSamarbeidsperiode
 import no.nav.lydia.api.nyFlytSamarbeidsplan
 import no.nav.lydia.api.nyFlytVirksomhet
 import no.nav.lydia.api.samarbeid
@@ -566,6 +567,12 @@ private fun Application.lydiaRestApi(
                 adGrupper = naisEnv.security.adGrupper,
                 auditLog = auditLog,
                 azureService = azureService,
+            )
+            nyFlytSamarbeidsperiode( // aka ia-sak
+                iaSakService = iaSakService,
+                nyFlytService = nyFlytService,
+                adGrupper = naisEnv.security.adGrupper,
+                auditLog = auditLog,
             )
             nyFlytSamarbeidsplan(
                 iaSakService = iaSakService,

--- a/src/main/kotlin/no/nav/lydia/App.kt
+++ b/src/main/kotlin/no/nav/lydia/App.kt
@@ -32,6 +32,7 @@ import no.nav.lydia.api.iaSakTeam
 import no.nav.lydia.api.iaSamarbeid
 import no.nav.lydia.api.nyFlyt
 import no.nav.lydia.api.nyFlytKartlegging
+import no.nav.lydia.api.nyFlytSamarbeid
 import no.nav.lydia.api.nyFlytSamarbeidsperiode
 import no.nav.lydia.api.nyFlytSamarbeidsplan
 import no.nav.lydia.api.nyFlytVirksomhet
@@ -573,6 +574,17 @@ private fun Application.lydiaRestApi(
                 nyFlytService = nyFlytService,
                 adGrupper = naisEnv.security.adGrupper,
                 auditLog = auditLog,
+            )
+            nyFlytSamarbeid(
+                iaSakService = iaSakService,
+                iASamarbeidService = samarbeidService,
+                nyFlytService = nyFlytService,
+                dokumentPubliseringService = dokumentPubliseringService,
+                planService = planService,
+                tilstandVirksomhetRepository = tilstandVirksomhetRepository,
+                adGrupper = naisEnv.security.adGrupper,
+                auditLog = auditLog,
+                azureService = azureService,
             )
             nyFlytSamarbeidsplan(
                 iaSakService = iaSakService,

--- a/src/main/kotlin/no/nav/lydia/App.kt
+++ b/src/main/kotlin/no/nav/lydia/App.kt
@@ -561,6 +561,7 @@ private fun Application.lydiaRestApi(
                 nyFlytService = nyFlytService,
                 dokumentPubliseringService = dokumentPubliseringService,
                 planService = planService,
+                virksomhetService = virksomhetService,
                 tilstandVirksomhetRepository = tilstandVirksomhetRepository,
                 adGrupper = naisEnv.security.adGrupper,
                 auditLog = auditLog,

--- a/src/main/kotlin/no/nav/lydia/App.kt
+++ b/src/main/kotlin/no/nav/lydia/App.kt
@@ -573,6 +573,7 @@ private fun Application.lydiaRestApi(
                 iaSakService = iaSakService,
                 nyFlytService = nyFlytService,
                 adGrupper = naisEnv.security.adGrupper,
+                azureService = azureService,
                 auditLog = auditLog,
             )
             nyFlytSamarbeid(

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -88,7 +88,7 @@ fun Route.nyFlyt(
             ),
         ).build(orgnr)
 
-    // TODO: delete me etter frontend er oppdatert med $NY_FLYT_API_PATH/virksomhet/{orgnummer}/$orgnr/tilstand
+    // TODO: delete me etter frontend er oppdatert med $NY_FLYT_API_PATH/virksomhet/{orgnummer}/tilstand
     get("$NY_FLYT_PATH/{orgnummer}/tilstand") {
         val orgnr = call.orgnummer ?: return@get call.respond(IASakError.`ugyldig orgnummer`)
 
@@ -126,6 +126,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med $NY_FLYT_API_PATH/virksomhet/{orgnummer}
     get("$NY_FLYT_PATH/virksomhet/{orgnummer}") {
         val orgnummer = call.parameters["orgnummer"] ?: return@get call.respond(SykefraværsstatistikkError.`ugyldig orgnummer`)
         call.somLesebruker(adGrupper = adGrupper) {

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -329,6 +329,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med POST $NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}/kartlegging/{type}
     post("$NY_FLYT_PATH/{orgnummer}/{samarbeidId}/opprett-kartlegging/{type}") {
         val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
         val samarbeidId = call.samarbeidId ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
@@ -363,6 +364,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med POST $NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}/kartlegging/{samarbeidId}/start
     post("$NY_FLYT_PATH/{orgnummer}/{samarbeidId}/start-kartlegging/{sporreundersokelseId}") {
         val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
         val tilstandsmaskin = tilstandsmaskin(orgnr)
@@ -393,6 +395,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med POST $NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}/kartlegging/{samarbeidId}/fullfor
     post("$NY_FLYT_PATH/{orgnummer}/{samarbeidId}/fullfor-kartlegging/{sporreundersokelseId}") {
         val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
         val tilstandsmaskin = tilstandsmaskin(orgnr)
@@ -423,6 +426,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med DELETE $NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}/kartlegging/{samarbeidId}
     delete("$NY_FLYT_PATH/{orgnummer}/{samarbeidId}/slett-kartlegging/{sporreundersokelseId}") {
         val orgnr = call.orgnummer ?: return@delete call.respond(IASakError.`ugyldig orgnummer`)
         val tilstandsmaskin = tilstandsmaskin(orgnr)
@@ -574,6 +578,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med PUT $NY_FLYT_API_PATH/virksomhet/{orgnummer}/endre-planlagt-dato
     put("$NY_FLYT_PATH/virksomhet/{orgnummer}/endre-planlagt-dato") {
         val orgnr = call.orgnummer ?: return@put call.sendFeil(IASakError.`ugyldig orgnummer`)
         val virksomhetTilstandAutomatiskOppdateringDto = call.receive<VirksomhetTilstandAutomatiskOppdateringDto>()
@@ -606,6 +611,7 @@ fun Route.nyFlyt(
 
     // -- Dette er tenkt å være en midlertidig løsning frem til vi har utviklet kontaktperson funksjonalitet i samarbeid med Salesforce.
     // -- Dette etterlater ingen hendelser, men skriver kun over eierskap i den akktive saken
+    // TODO: delete me etter frontend er oppdatert med PUT $NY_FLYT_API_PATH/virksomhet/{orgnummer}/bli-eier
     post("$NY_FLYT_PATH/{orgnummer}/bli-eier") {
         val orgnr = call.orgnummer ?: return@post call.sendFeil(IASakError.`ugyldig orgnummer`)
         call.somSaksbehandlerMedNavenhet(adGrupper, azureService) { saksbehandler, _ ->

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -494,6 +494,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med POST $NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}
     post("$NY_FLYT_PATH/{orgnummer}/{samarbeidId}/avslutt-samarbeid") {
         val orgnr = call.orgnummer ?: return@post call.sendFeil(IASakError.`ugyldig orgnummer`)
         val samarbeidId = call.samarbeidId ?: return@post call.sendFeil(IASamarbeidFeil.`ugyldig samarbeidId`)
@@ -540,6 +541,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med PATCH $NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}
     put("$NY_FLYT_PATH/virksomhet/{orgnummer}/samarbeid/{samarbeidId}/oppdater") {
         val orgnr = call.orgnummer ?: return@put call.sendFeil(IASakError.`ugyldig orgnummer`)
         val samarbeidId = call.samarbeidId ?: return@put call.sendFeil(IASakError.`ugyldig orgnummer`)

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -142,6 +142,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med $NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode
     get("$NY_FLYT_PATH/virksomhet/{orgnummer}/samarbeidsperiode") {
         val orgnr = call.orgnummer ?: return@get call.respond(IASakError.`ugyldig orgnummer`)
         call.somLesebruker(adGrupper) {
@@ -162,6 +163,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med $NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode
     get("$NY_FLYT_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}") {
         val orgnr = call.orgnummer ?: return@get call.respond(IASakError.`ugyldig orgnummer`)
         val saksnummer = call.saksnummer ?: return@get call.respond(IASakError.`ugyldig saksnummer`)

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -299,6 +299,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med POST $NY_FLYT_API_PATH/virksomhet/{orgnummer}/opprett-samarbeid
     post("$NY_FLYT_PATH/{orgnummer}/opprett-samarbeid") {
         val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
         val iaSamarbeidDto = call.receive<IASamarbeidDto>()

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -299,7 +299,7 @@ fun Route.nyFlyt(
         }
     }
 
-    // TODO: delete me etter frontend er oppdatert med POST $NY_FLYT_API_PATH/virksomhet/{orgnummer}/opprett-samarbeid
+    // TODO: delete me etter frontend er oppdatert med POST $NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid
     post("$NY_FLYT_PATH/{orgnummer}/opprett-samarbeid") {
         val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
         val iaSamarbeidDto = call.receive<IASamarbeidDto>()

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -184,6 +184,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med $NY_FLYT_API_PATH/virksomhet/{orgnummer}/historikk
     get("$NY_FLYT_PATH/virksomhet/{orgnummer}/historikk") {
         val orgnummer = call.orgnummer ?: return@get call.respond(IASakError.`ugyldig orgnummer`)
         call.somLesebruker(adGrupper = adGrupper) { _ ->

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -453,6 +453,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med DELETE $NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}
     delete("$NY_FLYT_PATH/{orgnummer}/{samarbeidId}/slett-samarbeid") {
         val orgnr = call.orgnummer ?: return@delete call.sendFeil(IASakError.`ugyldig orgnummer`)
         val samarbeidId = call.samarbeidId ?: return@delete call.sendFeil(IASamarbeidFeil.`ugyldig samarbeidId`)

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -88,6 +88,7 @@ fun Route.nyFlyt(
             ),
         ).build(orgnr)
 
+    // TODO: delete me etter frontend er oppdatert med $NY_FLYT_API_PATH/virksomhet/{orgnummer}/$orgnr/tilstand
     get("$NY_FLYT_PATH/{orgnummer}/tilstand") {
         val orgnr = call.orgnummer ?: return@get call.respond(IASakError.`ugyldig orgnummer`)
 

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -271,6 +271,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med POST $NY_FLYT_API_PATH/virksomhet/{orgnummer}/angre-vurdering
     post("$NY_FLYT_PATH/{orgnummer}/angre-vurdering") {
         val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
 

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytRoutes.kt
@@ -225,6 +225,7 @@ fun Route.nyFlyt(
         }
     }
 
+    // TODO: delete me etter frontend er oppdatert med POST $NY_FLYT_API_PATH/virksomhet/{orgnummer}/vurder
     post("$NY_FLYT_PATH/{orgnummer}/vurder") {
         val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
         val valgtÅrsak = runCatching { call.receiveNullable<ValgtÅrsak>() }.getOrNull()

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidRoutes.kt
@@ -5,6 +5,7 @@ import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
+import io.ktor.server.routing.patch
 import io.ktor.server.routing.post
 import no.nav.lydia.ADGrupper
 import no.nav.lydia.AuditLog
@@ -12,17 +13,22 @@ import no.nav.lydia.AuditType
 import no.nav.lydia.dokumentpublisering.DokumentPubliseringService
 import no.nav.lydia.felles.Feil
 import no.nav.lydia.integrasjoner.azure.AzureService
+import no.nav.lydia.samarbeid.EndringISamarbeidDto
+import no.nav.lydia.samarbeid.IASamarbeid
 import no.nav.lydia.samarbeid.IASamarbeidDto
 import no.nav.lydia.samarbeid.IASamarbeidFeil
 import no.nav.lydia.samarbeid.IASamarbeidService
 import no.nav.lydia.samarbeidsperiode.IASakError
 import no.nav.lydia.samarbeidsperiode.IASakService
 import no.nav.lydia.samarbeidsplan.PlanService
+import no.nav.lydia.samarbeidsplan.SamarbeidDto
 import no.nav.lydia.tilgangskontroll.somSaksbehandlerMedNavenhet
 import no.nav.lydia.tilstandsmaskin.FiaKontekst
 import no.nav.lydia.tilstandsmaskin.NyFlytService
 import no.nav.lydia.tilstandsmaskin.TilstandVirksomhetRepository
 import no.nav.lydia.tilstandsmaskin.TilstandsmaskinBuilder
+import no.nav.lydia.tilstandsmaskin.hendelse.AvsluttSamarbeid
+import no.nav.lydia.tilstandsmaskin.hendelse.EndreSamarbeidsNavn
 import no.nav.lydia.tilstandsmaskin.hendelse.OpprettNyttSamarbeid
 import no.nav.lydia.tilstandsmaskin.hendelse.SlettSamarbeid
 import java.time.LocalDate
@@ -81,6 +87,93 @@ fun Route.nyFlytSamarbeid(
             )
         }.map {
             call.respond(status = HttpStatusCode.Created, message = it)
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+
+    post("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}") {
+        val orgnr = call.orgnummer ?: return@post call.sendFeil(IASakError.`ugyldig orgnummer`)
+        val samarbeidId = call.samarbeidId ?: return@post call.sendFeil(IASamarbeidFeil.`ugyldig samarbeidId`)
+        val samarbeid = call.receive<SamarbeidDto>()
+        val typeAvslutning = samarbeid.status
+        if (typeAvslutning != IASamarbeid.Status.FULLFØRT && typeAvslutning != IASamarbeid.Status.AVBRUTT) {
+            return@post call.sendFeil(Feil(feilmelding = "Ugyldig avslutningstype", httpStatusCode = HttpStatusCode.BadRequest))
+        }
+        val datoParam = call.request.queryParameters["dato"]
+        val dato = datoParam?.let {
+            runCatching { LocalDate.parse(it) }.getOrElse {
+                return@post call.sendFeil(Feil(feilmelding = "Ugyldig datoformat", httpStatusCode = HttpStatusCode.BadRequest))
+            }
+        }
+        if (dato != null && dato.isBefore(LocalDate.now().plusDays(1))) {
+            return@post call.sendFeil(Feil(feilmelding = "Dato må være minst én dag frem i tid", httpStatusCode = HttpStatusCode.BadRequest))
+        }
+        val tilstandsmaskin = tilstandsmaskin(orgnr)
+
+        call.somSaksbehandlerMedNavenhet(adGrupper, azureService) { saksbehandler, navEnhet ->
+            val konsekvens = tilstandsmaskin.prosesserHendelse(
+                hendelse = AvsluttSamarbeid(
+                    orgnr = orgnr,
+                    samarbeidId = samarbeidId,
+                    typeAvslutning = typeAvslutning,
+                    saksbehandler = saksbehandler,
+                    navEnhet = navEnhet,
+                    dato = dato,
+                ),
+            )
+            konsekvens.map { it.verdi as IASamarbeidDto }
+        }.also { iaSamarbeidDtoEither ->
+            auditLog.auditloggEither(
+                call = call,
+                either = iaSamarbeidDtoEither,
+                orgnummer = orgnr,
+                auditType = AuditType.delete,
+                saksnummer = tilstandsmaskin.saksnummer,
+            )
+        }.map {
+            call.respond(status = HttpStatusCode.OK, message = it)
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+
+    patch("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}") {
+        val orgnr = call.orgnummer ?: return@patch call.sendFeil(IASakError.`ugyldig orgnummer`)
+        val samarbeidId = call.samarbeidId ?: return@patch call.sendFeil(IASakError.`ugyldig orgnummer`)
+        val endringISamarbeidDto = call.receive<EndringISamarbeidDto>()
+        if (endringISamarbeidDto.typeEndring != "navn") {
+            return@patch call.sendFeil(
+                Feil(
+                    feilmelding = "Feil type endring for samarbeid: '${endringISamarbeidDto.typeEndring}'",
+                    httpStatusCode = HttpStatusCode.BadRequest,
+                ),
+            )
+        }
+
+        val tilstandsmaskin = tilstandsmaskin(orgnr)
+
+        call.somSaksbehandlerMedNavenhet(adGrupper, azureService) { saksbehandler, navEnhet ->
+            val konsekvens = tilstandsmaskin.prosesserHendelse(
+                hendelse = EndreSamarbeidsNavn(
+                    orgnr = orgnr,
+                    samarbeidId = samarbeidId,
+                    navn = endringISamarbeidDto.verdi,
+                    saksbehandler = saksbehandler,
+                    navEnhet = navEnhet,
+                ),
+            )
+            konsekvens.map { it.verdi as IASamarbeidDto }
+        }.also { iaSamarbeidDtoEither ->
+            auditLog.auditloggEither(
+                call = call,
+                either = iaSamarbeidDtoEither,
+                orgnummer = orgnr,
+                auditType = AuditType.update,
+                saksnummer = tilstandsmaskin.saksnummer,
+            )
+        }.map {
+            call.respond(status = HttpStatusCode.OK, message = it)
         }.mapLeft {
             call.respond(status = it.httpStatusCode, message = it.feilmelding)
         }

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidRoutes.kt
@@ -4,13 +4,16 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
 import io.ktor.server.routing.post
 import no.nav.lydia.ADGrupper
 import no.nav.lydia.AuditLog
 import no.nav.lydia.AuditType
 import no.nav.lydia.dokumentpublisering.DokumentPubliseringService
+import no.nav.lydia.felles.Feil
 import no.nav.lydia.integrasjoner.azure.AzureService
 import no.nav.lydia.samarbeid.IASamarbeidDto
+import no.nav.lydia.samarbeid.IASamarbeidFeil
 import no.nav.lydia.samarbeid.IASamarbeidService
 import no.nav.lydia.samarbeidsperiode.IASakError
 import no.nav.lydia.samarbeidsperiode.IASakService
@@ -21,6 +24,8 @@ import no.nav.lydia.tilstandsmaskin.NyFlytService
 import no.nav.lydia.tilstandsmaskin.TilstandVirksomhetRepository
 import no.nav.lydia.tilstandsmaskin.TilstandsmaskinBuilder
 import no.nav.lydia.tilstandsmaskin.hendelse.OpprettNyttSamarbeid
+import no.nav.lydia.tilstandsmaskin.hendelse.SlettSamarbeid
+import java.time.LocalDate
 
 fun Route.nyFlytSamarbeid(
     iaSakService: IASakService,
@@ -76,6 +81,47 @@ fun Route.nyFlytSamarbeid(
             )
         }.map {
             call.respond(status = HttpStatusCode.Created, message = it)
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+
+    // DELETE
+    delete("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}") {
+        val orgnr = call.orgnummer ?: return@delete call.sendFeil(IASakError.`ugyldig orgnummer`)
+        val samarbeidId = call.samarbeidId ?: return@delete call.sendFeil(IASamarbeidFeil.`ugyldig samarbeidId`)
+        val datoParam = call.request.queryParameters["dato"]
+        val dato = datoParam?.let {
+            runCatching { LocalDate.parse(it) }.getOrElse {
+                return@delete call.sendFeil(Feil(feilmelding = "Ugyldig datoformat", httpStatusCode = HttpStatusCode.BadRequest))
+            }
+        }
+        if (dato != null && dato.isBefore(LocalDate.now().plusDays(1))) {
+            return@delete call.sendFeil(Feil(feilmelding = "Dato må være minst én dag frem i tid", httpStatusCode = HttpStatusCode.BadRequest))
+        }
+        val tilstandsmaskin = tilstandsmaskin(orgnr)
+
+        call.somSaksbehandlerMedNavenhet(adGrupper, azureService) { saksbehandler, navEnhet ->
+            val konsekvens = tilstandsmaskin.prosesserHendelse(
+                hendelse = SlettSamarbeid(
+                    orgnr = orgnr,
+                    samarbeidId = samarbeidId,
+                    saksbehandler = saksbehandler,
+                    navEnhet = navEnhet,
+                    dato = dato,
+                ),
+            )
+            konsekvens.map { it.verdi as IASamarbeidDto }
+        }.also { iaSamarbeidDtoEither ->
+            auditLog.auditloggEither(
+                call = call,
+                either = iaSamarbeidDtoEither,
+                orgnummer = orgnr,
+                auditType = AuditType.delete,
+                saksnummer = tilstandsmaskin.saksnummer,
+            )
+        }.map {
+            call.respond(status = HttpStatusCode.OK, message = it)
         }.mapLeft {
             call.respond(status = it.httpStatusCode, message = it.feilmelding)
         }

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidRoutes.kt
@@ -1,0 +1,83 @@
+package no.nav.lydia.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import no.nav.lydia.ADGrupper
+import no.nav.lydia.AuditLog
+import no.nav.lydia.AuditType
+import no.nav.lydia.dokumentpublisering.DokumentPubliseringService
+import no.nav.lydia.integrasjoner.azure.AzureService
+import no.nav.lydia.samarbeid.IASamarbeidDto
+import no.nav.lydia.samarbeid.IASamarbeidService
+import no.nav.lydia.samarbeidsperiode.IASakError
+import no.nav.lydia.samarbeidsperiode.IASakService
+import no.nav.lydia.samarbeidsplan.PlanService
+import no.nav.lydia.tilgangskontroll.somSaksbehandlerMedNavenhet
+import no.nav.lydia.tilstandsmaskin.FiaKontekst
+import no.nav.lydia.tilstandsmaskin.NyFlytService
+import no.nav.lydia.tilstandsmaskin.TilstandVirksomhetRepository
+import no.nav.lydia.tilstandsmaskin.TilstandsmaskinBuilder
+import no.nav.lydia.tilstandsmaskin.hendelse.OpprettNyttSamarbeid
+
+fun Route.nyFlytSamarbeid(
+    iaSakService: IASakService,
+    iASamarbeidService: IASamarbeidService,
+    nyFlytService: NyFlytService,
+    dokumentPubliseringService: DokumentPubliseringService,
+    planService: PlanService,
+    tilstandVirksomhetRepository: TilstandVirksomhetRepository,
+    adGrupper: ADGrupper,
+    auditLog: AuditLog,
+    azureService: AzureService,
+) {
+    fun tilstandsmaskin(orgnr: String) =
+        TilstandsmaskinBuilder.medKontekst(
+            fiaKontekst = FiaKontekst(
+                iaSakService = iaSakService,
+                iASamarbeidService = iASamarbeidService,
+                nyFlytService = nyFlytService,
+                dokumentPubliseringService = dokumentPubliseringService,
+                planService = planService,
+                tilstandVirksomhetRepository = tilstandVirksomhetRepository,
+                saksnummer = nyFlytService.hentSisteIASakDto(orgnr)?.saksnummer,
+            ),
+        ).build(orgnr)
+
+    // POST
+    post("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid") {
+        val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
+        val saksnummer = call.saksnummer ?: return@post call.respond(IASakError.`ugyldig saksnummer`)
+        val iaSamarbeidDto = call.receive<IASamarbeidDto>()
+
+        if (saksnummer != iaSamarbeidDto.saksnummer) {
+            return@post call.respond(status = HttpStatusCode.BadRequest, message = "Ugyldig saksnummer")
+        }
+
+        call.somSaksbehandlerMedNavenhet(adGrupper, azureService) { saksbehandler, navEnhet ->
+            val konsekvens = tilstandsmaskin(orgnr).prosesserHendelse(
+                hendelse = OpprettNyttSamarbeid(
+                    orgnr = orgnr,
+                    samarbeidsnavn = iaSamarbeidDto.navn,
+                    saksbehandler = saksbehandler,
+                    navEnhet = navEnhet,
+                ),
+            )
+            konsekvens.map { it.verdi as IASamarbeidDto }
+        }.also { iaSamarbeidDtoEither ->
+            auditLog.auditloggEither(
+                call = call,
+                either = iaSamarbeidDtoEither,
+                orgnummer = orgnr,
+                auditType = AuditType.create,
+                saksnummer = iaSamarbeidDtoEither.map { iaSamarbeid -> iaSamarbeid.saksnummer }.getOrNull(),
+            )
+        }.map {
+            call.respond(status = HttpStatusCode.Created, message = it)
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidsperiodeRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidsperiodeRoutes.kt
@@ -1,0 +1,64 @@
+package no.nav.lydia.api
+
+import arrow.core.left
+import arrow.core.right
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import no.nav.lydia.ADGrupper
+import no.nav.lydia.AuditLog
+import no.nav.lydia.AuditType
+import no.nav.lydia.felles.Feil
+import no.nav.lydia.samarbeidsperiode.IASakError
+import no.nav.lydia.samarbeidsperiode.IASakService
+import no.nav.lydia.tilgangskontroll.somLesebruker
+import no.nav.lydia.tilstandsmaskin.NyFlytService
+
+fun Route.nyFlytSamarbeidsperiode(
+    iaSakService: IASakService,
+    nyFlytService: NyFlytService,
+    adGrupper: ADGrupper,
+    auditLog: AuditLog,
+) {
+    // GET
+    get("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode") {
+        val orgnr = call.orgnummer ?: return@get call.respond(IASakError.`ugyldig orgnummer`)
+        call.somLesebruker(adGrupper) {
+            nyFlytService.hentSisteIASakDto(orgnr)?.right()
+                ?: Feil(feilmelding = "Fant ingen aktiv sak på virksomheten", httpStatusCode = HttpStatusCode.NoContent).left()
+        }.also { iaSakEither ->
+            auditLog.auditloggEither(
+                call = call,
+                either = iaSakEither,
+                orgnummer = orgnr,
+                auditType = AuditType.access,
+                saksnummer = iaSakEither.map { iaSak -> iaSak.saksnummer }.getOrNull(),
+            )
+        }.map {
+            call.respond(status = HttpStatusCode.OK, message = it)
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+
+    get("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}") {
+        val orgnr = call.orgnummer ?: return@get call.respond(IASakError.`ugyldig orgnummer`)
+        val saksnummer = call.saksnummer ?: return@get call.respond(IASakError.`ugyldig saksnummer`)
+        call.somLesebruker(adGrupper = adGrupper) {
+            iaSakService.hentIASakDto(saksnummer)
+        }.also { either ->
+            auditLog.auditloggEither(
+                call = call,
+                either = either,
+                orgnummer = orgnr,
+                auditType = AuditType.access,
+                saksnummer = saksnummer,
+            )
+        }.map {
+            call.respond(status = HttpStatusCode.OK, message = it)
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidsperiodeRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytSamarbeidsperiodeRoutes.kt
@@ -6,19 +6,23 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import no.nav.lydia.ADGrupper
 import no.nav.lydia.AuditLog
 import no.nav.lydia.AuditType
 import no.nav.lydia.felles.Feil
+import no.nav.lydia.integrasjoner.azure.AzureService
 import no.nav.lydia.samarbeidsperiode.IASakError
 import no.nav.lydia.samarbeidsperiode.IASakService
 import no.nav.lydia.tilgangskontroll.somLesebruker
+import no.nav.lydia.tilgangskontroll.somSaksbehandlerMedNavenhet
 import no.nav.lydia.tilstandsmaskin.NyFlytService
 
 fun Route.nyFlytSamarbeidsperiode(
     iaSakService: IASakService,
     nyFlytService: NyFlytService,
     adGrupper: ADGrupper,
+    azureService: AzureService,
     auditLog: AuditLog,
 ) {
     // GET
@@ -54,6 +58,30 @@ fun Route.nyFlytSamarbeidsperiode(
                 orgnummer = orgnr,
                 auditType = AuditType.access,
                 saksnummer = saksnummer,
+            )
+        }.map {
+            call.respond(status = HttpStatusCode.OK, message = it)
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+
+    // POST
+    // -- Dette er tenkt å være en midlertidig løsning frem til vi har utviklet kontaktperson funksjonalitet i samarbeid med Salesforce.
+    // -- Dette etterlater ingen hendelser, men skriver kun over eierskap i den akktive saken
+    post("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/bli-eier") {
+        val orgnr = call.orgnummer ?: return@post call.sendFeil(IASakError.`ugyldig orgnummer`)
+        val saksnummer = call.saksnummer ?: return@post call.sendFeil(IASakError.`ugyldig saksnummer`)
+
+        call.somSaksbehandlerMedNavenhet(adGrupper, azureService) { saksbehandler, _ ->
+            nyFlytService.bliEier(orgnr = orgnr, saksnummer = saksnummer, navAnsatt = saksbehandler)
+        }.also { iaSamarbeidDtoEither ->
+            auditLog.auditloggEither(
+                call = call,
+                either = iaSamarbeidDtoEither,
+                orgnummer = orgnr,
+                auditType = AuditType.delete,
+                saksnummer = iaSamarbeidDtoEither.getOrNull()?.saksnummer,
             )
         }.map {
             call.respond(status = HttpStatusCode.OK, message = it)

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
@@ -1,9 +1,11 @@
 package no.nav.lydia.api
 
+import arrow.core.right
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import kotlinx.datetime.toJavaLocalDate
 import no.nav.lydia.ADGrupper
@@ -11,6 +13,7 @@ import no.nav.lydia.AuditLog
 import no.nav.lydia.AuditType
 import no.nav.lydia.dokumentpublisering.DokumentPubliseringService
 import no.nav.lydia.integrasjoner.azure.AzureService
+import no.nav.lydia.prioritering.virksomhet.VirksomhetService
 import no.nav.lydia.samarbeid.IASamarbeidService
 import no.nav.lydia.samarbeidsperiode.IASakDto
 import no.nav.lydia.samarbeidsperiode.IASakError
@@ -18,11 +21,14 @@ import no.nav.lydia.samarbeidsperiode.IASakService
 import no.nav.lydia.samarbeidsperiode.ValgtÅrsak
 import no.nav.lydia.samarbeidsperiode.validerBegrunnelserForVurdering
 import no.nav.lydia.samarbeidsplan.PlanService
+import no.nav.lydia.tilgangskontroll.somLesebruker
 import no.nav.lydia.tilgangskontroll.somSaksbehandlerMedNavenhet
 import no.nav.lydia.tilstandsmaskin.FiaKontekst
 import no.nav.lydia.tilstandsmaskin.NyFlytService
 import no.nav.lydia.tilstandsmaskin.TilstandVirksomhetRepository
 import no.nav.lydia.tilstandsmaskin.TilstandsmaskinBuilder
+import no.nav.lydia.tilstandsmaskin.VirksomhetIATilstand
+import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandDto
 import no.nav.lydia.tilstandsmaskin.hendelse.AvsluttVurdering
 import java.time.LocalDate
 
@@ -32,6 +38,7 @@ fun Route.nyFlytVirksomhet(
     nyFlytService: NyFlytService,
     dokumentPubliseringService: DokumentPubliseringService,
     planService: PlanService,
+    virksomhetService: VirksomhetService,
     tilstandVirksomhetRepository: TilstandVirksomhetRepository,
     adGrupper: ADGrupper,
     auditLog: AuditLog,
@@ -50,6 +57,45 @@ fun Route.nyFlytVirksomhet(
             ),
         ).build(orgnr)
 
+    // GET
+    get("${NY_FLYT_API_PATH}/virksomhet/{orgnummer}/tilstand") {
+        val orgnr = call.orgnummer ?: return@get call.respond(IASakError.`ugyldig orgnummer`)
+
+        call.somLesebruker(adGrupper) {
+            tilstandsmaskin(orgnr).hentTilstandForVirksomhet(orgnr = orgnr).right()
+        }.also { tilstandEither ->
+            auditLog.auditloggEither(
+                call = call,
+                either = tilstandEither,
+                orgnummer = orgnr,
+                auditType = AuditType.access,
+            )
+        }.map { virksomhetTilstandDto: VirksomhetTilstandDto? ->
+            if (virksomhetTilstandDto == null) {
+                val virksomhetFinnes = virksomhetService.hentVirksomhet(orgnr) != null
+                if (!virksomhetFinnes) {
+                    call.respond(
+                        status = HttpStatusCode.NotFound,
+                        message = "Virksomheten finnes ikke for orgnr $orgnr",
+                    )
+                } else {
+                    call.respond(
+                        status = HttpStatusCode.OK,
+                        message = VirksomhetTilstandDto(
+                            orgnr = orgnr,
+                            tilstand = VirksomhetIATilstand.VirksomhetKlarTilVurdering,
+                        ),
+                    )
+                }
+            } else {
+                call.respond(status = HttpStatusCode.OK, message = virksomhetTilstandDto)
+            }
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+
+    // POST
     post("${NY_FLYT_API_PATH}/virksomhet/{orgnummer}/avslutt-vurdering") {
         val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
         val årsak = call.receive<ValgtÅrsak>()

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
@@ -20,6 +20,7 @@ import no.nav.lydia.felles.Feil
 import no.nav.lydia.integrasjoner.azure.AzureService
 import no.nav.lydia.prioritering.virksomhet.VirksomhetService
 import no.nav.lydia.prioritering.virksomhet.toDto
+import no.nav.lydia.samarbeid.IASamarbeidDto
 import no.nav.lydia.samarbeid.IASamarbeidService
 import no.nav.lydia.samarbeid.tilDto
 import no.nav.lydia.samarbeidsperiode.IASakDto
@@ -42,6 +43,7 @@ import no.nav.lydia.tilstandsmaskin.VirksomhetIATilstand
 import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandDto
 import no.nav.lydia.tilstandsmaskin.hendelse.AngreVurderVirksomhet
 import no.nav.lydia.tilstandsmaskin.hendelse.AvsluttVurdering
+import no.nav.lydia.tilstandsmaskin.hendelse.OpprettNyttSamarbeid
 import no.nav.lydia.tilstandsmaskin.hendelse.VurderVirksomhet
 import java.time.LocalDate
 import kotlin.collections.List
@@ -276,6 +278,35 @@ fun Route.nyFlytVirksomhet(
             )
         }.map {
             call.respond(status = HttpStatusCode.OK, message = it)
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+
+    post("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/opprett-samarbeid") {
+        val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
+        val iaSamarbeidDto = call.receive<IASamarbeidDto>()
+
+        call.somSaksbehandlerMedNavenhet(adGrupper, azureService) { saksbehandler, navEnhet ->
+            val konsekvens = tilstandsmaskin(orgnr).prosesserHendelse(
+                hendelse = OpprettNyttSamarbeid(
+                    orgnr = orgnr,
+                    samarbeidsnavn = iaSamarbeidDto.navn,
+                    saksbehandler = saksbehandler,
+                    navEnhet = navEnhet,
+                ),
+            )
+            konsekvens.map { it.verdi as IASamarbeidDto }
+        }.also { iaSamarbeidDtoEither ->
+            auditLog.auditloggEither(
+                call = call,
+                either = iaSamarbeidDtoEither,
+                orgnummer = orgnr,
+                auditType = AuditType.create,
+                saksnummer = iaSamarbeidDtoEither.map { iaSamarbeid -> iaSamarbeid.saksnummer }.getOrNull(),
+            )
+        }.map {
+            call.respond(status = HttpStatusCode.Created, message = it)
         }.mapLeft {
             call.respond(status = it.httpStatusCode, message = it.feilmelding)
         }

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
@@ -11,6 +11,7 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
+import io.ktor.server.routing.put
 import kotlinx.datetime.toJavaLocalDate
 import no.nav.lydia.ADGrupper
 import no.nav.lydia.AuditLog
@@ -39,9 +40,11 @@ import no.nav.lydia.tilstandsmaskin.NyFlytService
 import no.nav.lydia.tilstandsmaskin.TilstandVirksomhetRepository
 import no.nav.lydia.tilstandsmaskin.TilstandsmaskinBuilder
 import no.nav.lydia.tilstandsmaskin.VirksomhetIATilstand
+import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandAutomatiskOppdateringDto
 import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandDto
 import no.nav.lydia.tilstandsmaskin.hendelse.AngreVurderVirksomhet
 import no.nav.lydia.tilstandsmaskin.hendelse.AvsluttVurdering
+import no.nav.lydia.tilstandsmaskin.hendelse.EndrePlanlagtDatoForNesteTilstand
 import no.nav.lydia.tilstandsmaskin.hendelse.VurderVirksomhet
 import java.time.LocalDate
 
@@ -271,6 +274,37 @@ fun Route.nyFlytVirksomhet(
                 orgnummer = orgnr,
                 auditType = AuditType.update,
                 saksnummer = iaSakEither.map { iaSak -> iaSak.saksnummer }.getOrNull(),
+            )
+        }.map {
+            call.respond(status = HttpStatusCode.OK, message = it)
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+
+    // PUT
+    put("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/endre-planlagt-dato") {
+        val orgnr = call.orgnummer ?: return@put call.sendFeil(IASakError.`ugyldig orgnummer`)
+        val virksomhetTilstandAutomatiskOppdateringDto = call.receive<VirksomhetTilstandAutomatiskOppdateringDto>()
+        val tilstandsmaskin = tilstandsmaskin(orgnr)
+
+        call.somSaksbehandlerMedNavenhet(adGrupper, azureService) { saksbehandler, navEnhet ->
+            val konsekvens = tilstandsmaskin.prosesserHendelse(
+                hendelse = EndrePlanlagtDatoForNesteTilstand(
+                    orgnr = orgnr,
+                    nyPlanlagtDato = virksomhetTilstandAutomatiskOppdateringDto.planlagtDato.toJavaLocalDate(),
+                    saksbehandler = saksbehandler,
+                    navEnhet = navEnhet,
+                ),
+            )
+            konsekvens.map { it.verdi as VirksomhetTilstandAutomatiskOppdateringDto }
+        }.also { either ->
+            auditLog.auditloggEither(
+                call = call,
+                either = either,
+                orgnummer = orgnr,
+                auditType = AuditType.update,
+                saksnummer = tilstandsmaskin.saksnummer,
             )
         }.map {
             call.respond(status = HttpStatusCode.OK, message = it)

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
@@ -1,5 +1,7 @@
 package no.nav.lydia.api
 
+import arrow.core.Either
+import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.right
 import io.ktor.http.HttpStatusCode
@@ -13,14 +15,18 @@ import no.nav.lydia.ADGrupper
 import no.nav.lydia.AuditLog
 import no.nav.lydia.AuditType
 import no.nav.lydia.dokumentpublisering.DokumentPubliseringService
+import no.nav.lydia.felles.Feil
 import no.nav.lydia.integrasjoner.azure.AzureService
 import no.nav.lydia.prioritering.virksomhet.VirksomhetService
 import no.nav.lydia.prioritering.virksomhet.toDto
 import no.nav.lydia.samarbeid.IASamarbeidService
+import no.nav.lydia.samarbeid.tilDto
 import no.nav.lydia.samarbeidsperiode.IASakDto
 import no.nav.lydia.samarbeidsperiode.IASakError
 import no.nav.lydia.samarbeidsperiode.IASakService
+import no.nav.lydia.samarbeidsperiode.SakshistorikkDto
 import no.nav.lydia.samarbeidsperiode.ValgtÅrsak
+import no.nav.lydia.samarbeidsperiode.tilSakshistorikk
 import no.nav.lydia.samarbeidsperiode.validerBegrunnelserForVurdering
 import no.nav.lydia.samarbeidsplan.PlanService
 import no.nav.lydia.tilgangskontroll.somLesebruker
@@ -33,6 +39,8 @@ import no.nav.lydia.tilstandsmaskin.VirksomhetIATilstand
 import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandDto
 import no.nav.lydia.tilstandsmaskin.hendelse.AvsluttVurdering
 import java.time.LocalDate
+import kotlin.collections.List
+import kotlin.collections.forEach
 
 fun Route.nyFlytVirksomhet(
     iaSakService: IASakService,
@@ -72,6 +80,46 @@ fun Route.nyFlytVirksomhet(
             call.respond(HttpStatusCode.OK, it)
         }.mapLeft {
             call.respond(it.httpStatusCode, it.feilmelding)
+        }
+    }
+
+    get("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/historikk") {
+        val orgnummer = call.orgnummer ?: return@get call.respond(IASakError.`ugyldig orgnummer`)
+        call.somLesebruker(adGrupper = adGrupper) { _ ->
+            val hendelser = iaSakService.hentHendelserForOrgnummer(orgnr = orgnummer)
+            iaSakService.hentIASakDtoerForOrgnummer(orgnummer = orgnummer)
+                .map { sak ->
+                    sak.addHendelser(hendelser = hendelser.filter { hendelse -> hendelse.saksnummer == sak.saksnummer })
+                }
+                .sortedByDescending { it.opprettetTidspunkt }
+                .map { iASakDto ->
+                    val samarbeid = nyFlytService.hentSamarbeidSomIkkeErSlettet(iASakDto.saksnummer).getOrElse { emptyList() }
+                    iASakDto.tilSakshistorikk(samarbeid = samarbeid.tilDto())
+                }.right()
+        }.also { either: Either<Feil, List<SakshistorikkDto>> ->
+            if (either.isLeft()) {
+                auditLog.auditloggEither(
+                    call = call,
+                    either = either,
+                    orgnummer = orgnummer,
+                    auditType = AuditType.access,
+                )
+            } else {
+                val sakshistorikkDtoListe: List<SakshistorikkDto> = either.getOrElse { listOf() }
+                sakshistorikkDtoListe.forEach { sakshistorikkDto ->
+                    auditLog.auditloggEither(
+                        call = call,
+                        either = either,
+                        orgnummer = orgnummer,
+                        auditType = AuditType.access,
+                        saksnummer = sakshistorikkDto.saksnummer,
+                    )
+                }
+            }
+        }.map { historikk ->
+            call.respond(historikk).right()
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
         }
     }
 

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
@@ -20,7 +20,6 @@ import no.nav.lydia.felles.Feil
 import no.nav.lydia.integrasjoner.azure.AzureService
 import no.nav.lydia.prioritering.virksomhet.VirksomhetService
 import no.nav.lydia.prioritering.virksomhet.toDto
-import no.nav.lydia.samarbeid.IASamarbeidDto
 import no.nav.lydia.samarbeid.IASamarbeidService
 import no.nav.lydia.samarbeid.tilDto
 import no.nav.lydia.samarbeidsperiode.IASakDto
@@ -43,11 +42,8 @@ import no.nav.lydia.tilstandsmaskin.VirksomhetIATilstand
 import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandDto
 import no.nav.lydia.tilstandsmaskin.hendelse.AngreVurderVirksomhet
 import no.nav.lydia.tilstandsmaskin.hendelse.AvsluttVurdering
-import no.nav.lydia.tilstandsmaskin.hendelse.OpprettNyttSamarbeid
 import no.nav.lydia.tilstandsmaskin.hendelse.VurderVirksomhet
 import java.time.LocalDate
-import kotlin.collections.List
-import kotlin.collections.forEach
 
 fun Route.nyFlytVirksomhet(
     iaSakService: IASakService,
@@ -278,35 +274,6 @@ fun Route.nyFlytVirksomhet(
             )
         }.map {
             call.respond(status = HttpStatusCode.OK, message = it)
-        }.mapLeft {
-            call.respond(status = it.httpStatusCode, message = it.feilmelding)
-        }
-    }
-
-    post("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/opprett-samarbeid") {
-        val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
-        val iaSamarbeidDto = call.receive<IASamarbeidDto>()
-
-        call.somSaksbehandlerMedNavenhet(adGrupper, azureService) { saksbehandler, navEnhet ->
-            val konsekvens = tilstandsmaskin(orgnr).prosesserHendelse(
-                hendelse = OpprettNyttSamarbeid(
-                    orgnr = orgnr,
-                    samarbeidsnavn = iaSamarbeidDto.navn,
-                    saksbehandler = saksbehandler,
-                    navEnhet = navEnhet,
-                ),
-            )
-            konsekvens.map { it.verdi as IASamarbeidDto }
-        }.also { iaSamarbeidDtoEither ->
-            auditLog.auditloggEither(
-                call = call,
-                either = iaSamarbeidDtoEither,
-                orgnummer = orgnr,
-                auditType = AuditType.create,
-                saksnummer = iaSamarbeidDtoEither.map { iaSamarbeid -> iaSamarbeid.saksnummer }.getOrNull(),
-            )
-        }.map {
-            call.respond(status = HttpStatusCode.Created, message = it)
         }.mapLeft {
             call.respond(status = it.httpStatusCode, message = it.feilmelding)
         }

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
@@ -6,6 +6,7 @@ import arrow.core.left
 import arrow.core.right
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
+import io.ktor.server.request.receiveNullable
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
@@ -28,9 +29,11 @@ import no.nav.lydia.samarbeidsperiode.SakshistorikkDto
 import no.nav.lydia.samarbeidsperiode.ValgtÅrsak
 import no.nav.lydia.samarbeidsperiode.tilSakshistorikk
 import no.nav.lydia.samarbeidsperiode.validerBegrunnelserForVurdering
+import no.nav.lydia.samarbeidsperiode.validerBegrunnelserForVurderingAvVirksomhet
 import no.nav.lydia.samarbeidsplan.PlanService
 import no.nav.lydia.tilgangskontroll.somLesebruker
 import no.nav.lydia.tilgangskontroll.somSaksbehandlerMedNavenhet
+import no.nav.lydia.tilgangskontroll.somSuperbrukerMedNavenhet
 import no.nav.lydia.tilstandsmaskin.FiaKontekst
 import no.nav.lydia.tilstandsmaskin.NyFlytService
 import no.nav.lydia.tilstandsmaskin.TilstandVirksomhetRepository
@@ -38,6 +41,7 @@ import no.nav.lydia.tilstandsmaskin.TilstandsmaskinBuilder
 import no.nav.lydia.tilstandsmaskin.VirksomhetIATilstand
 import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandDto
 import no.nav.lydia.tilstandsmaskin.hendelse.AvsluttVurdering
+import no.nav.lydia.tilstandsmaskin.hendelse.VurderVirksomhet
 import java.time.LocalDate
 import kotlin.collections.List
 import kotlin.collections.forEach
@@ -123,7 +127,7 @@ fun Route.nyFlytVirksomhet(
         }
     }
 
-    get("${NY_FLYT_API_PATH}/virksomhet/{orgnummer}/tilstand") {
+    get("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/tilstand") {
         val orgnr = call.orgnummer ?: return@get call.respond(IASakError.`ugyldig orgnummer`)
 
         call.somLesebruker(adGrupper) {
@@ -161,7 +165,52 @@ fun Route.nyFlytVirksomhet(
     }
 
     // POST
-    post("${NY_FLYT_API_PATH}/virksomhet/{orgnummer}/avslutt-vurdering") {
+    post("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/vurder") {
+        val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
+        val valgtÅrsak = runCatching { call.receiveNullable<ValgtÅrsak>() }.getOrNull()
+
+        if (valgtÅrsak == null) {
+            return@post call.respond(
+                status = HttpStatusCode.BadRequest,
+                message = "Mangler årsak og begrunnelse for vurdering av virksomhet",
+            )
+        }
+
+        if (!valgtÅrsak.validerBegrunnelserForVurderingAvVirksomhet()) {
+            return@post call.respond(
+                status = HttpStatusCode.BadRequest,
+                message = "Ugyldig årsak eller begrunnelse for vurdering av virksomhet",
+            )
+        }
+
+        call.somSuperbrukerMedNavenhet(adGrupper, azureService) { superbruker, navEnhet ->
+            val hendelse = VurderVirksomhet(
+                orgnr = orgnr,
+                superbruker = superbruker,
+                navEnhet = navEnhet,
+                valgtÅrsak = valgtÅrsak,
+            )
+            val konsekvens = tilstandsmaskin(orgnr).prosesserHendelse(
+                hendelse = hendelse,
+            )
+
+            konsekvens.map { it.verdi as IASakDto }
+        }.also { iaSakEither ->
+            auditLog.auditloggEither(
+                call = call,
+                either = iaSakEither,
+                orgnummer = orgnr,
+                auditType = AuditType.create,
+                saksnummer = iaSakEither.map { iaSak -> iaSak.saksnummer }.getOrNull(),
+            )
+        }.map {
+            call.respond(status = HttpStatusCode.Created, message = it)
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+
+    post("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/avslutt-vurdering") {
         val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
         val årsak = call.receive<ValgtÅrsak>()
 

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
@@ -1,5 +1,6 @@
 package no.nav.lydia.api
 
+import arrow.core.left
 import arrow.core.right
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
@@ -14,6 +15,7 @@ import no.nav.lydia.AuditType
 import no.nav.lydia.dokumentpublisering.DokumentPubliseringService
 import no.nav.lydia.integrasjoner.azure.AzureService
 import no.nav.lydia.prioritering.virksomhet.VirksomhetService
+import no.nav.lydia.prioritering.virksomhet.toDto
 import no.nav.lydia.samarbeid.IASamarbeidService
 import no.nav.lydia.samarbeidsperiode.IASakDto
 import no.nav.lydia.samarbeidsperiode.IASakError
@@ -58,6 +60,21 @@ fun Route.nyFlytVirksomhet(
         ).build(orgnr)
 
     // GET
+    get("$NY_FLYT_API_PATH/virksomhet/{orgnummer}") {
+        val orgnummer = call.parameters["orgnummer"] ?: return@get call.respond(SykefraværsstatistikkError.`ugyldig orgnummer`)
+        call.somLesebruker(adGrupper = adGrupper) {
+            val aktivSakDto = nyFlytService.hentSisteIASakDto(orgnummer)
+            virksomhetService.hentVirksomhet(orgnr = orgnummer)?.toDto(saksnummer = aktivSakDto?.saksnummer)
+                ?.right() ?: VirksomhetFeil.`fant ikke virksomhet`.left()
+        }.also {
+            auditLog.auditloggEither(call = call, either = it, orgnummer = orgnummer, auditType = AuditType.access)
+        }.map {
+            call.respond(HttpStatusCode.OK, it)
+        }.mapLeft {
+            call.respond(it.httpStatusCode, it.feilmelding)
+        }
+    }
+
     get("${NY_FLYT_API_PATH}/virksomhet/{orgnummer}/tilstand") {
         val orgnr = call.orgnummer ?: return@get call.respond(IASakError.`ugyldig orgnummer`)
 

--- a/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
+++ b/src/main/kotlin/no/nav/lydia/api/NyFlytVirksomhetRoutes.kt
@@ -40,6 +40,7 @@ import no.nav.lydia.tilstandsmaskin.TilstandVirksomhetRepository
 import no.nav.lydia.tilstandsmaskin.TilstandsmaskinBuilder
 import no.nav.lydia.tilstandsmaskin.VirksomhetIATilstand
 import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandDto
+import no.nav.lydia.tilstandsmaskin.hendelse.AngreVurderVirksomhet
 import no.nav.lydia.tilstandsmaskin.hendelse.AvsluttVurdering
 import no.nav.lydia.tilstandsmaskin.hendelse.VurderVirksomhet
 import java.time.LocalDate
@@ -205,6 +206,33 @@ fun Route.nyFlytVirksomhet(
             )
         }.map {
             call.respond(status = HttpStatusCode.Created, message = it)
+        }.mapLeft {
+            call.respond(status = it.httpStatusCode, message = it.feilmelding)
+        }
+    }
+
+    post("$NY_FLYT_API_PATH/virksomhet/{orgnummer}/angre-vurdering") {
+        val orgnr = call.orgnummer ?: return@post call.respond(IASakError.`ugyldig orgnummer`)
+
+        call.somSuperbrukerMedNavenhet(adGrupper, azureService) { superbruker, enhet ->
+            val konsekvens = tilstandsmaskin(orgnr).prosesserHendelse(
+                hendelse = AngreVurderVirksomhet(
+                    orgnr = orgnr,
+                    superbruker = superbruker,
+                    navEnhet = enhet,
+                ),
+            )
+            konsekvens.map { it.verdi as IASakDto }
+        }.also { iaSakEither ->
+            auditLog.auditloggEither(
+                call = call,
+                either = iaSakEither,
+                orgnummer = orgnr,
+                auditType = AuditType.delete,
+                saksnummer = iaSakEither.map { iaSak -> iaSak.saksnummer }.getOrNull(),
+            )
+        }.map {
+            call.respond(status = HttpStatusCode.OK, message = it)
         }.mapLeft {
             call.respond(status = it.httpStatusCode, message = it.feilmelding)
         }

--- a/src/main/kotlin/no/nav/lydia/samarbeid/EndringISamarbeidDto.kt
+++ b/src/main/kotlin/no/nav/lydia/samarbeid/EndringISamarbeidDto.kt
@@ -1,0 +1,9 @@
+package no.nav.lydia.samarbeid
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EndringISamarbeidDto(
+    val typeEndring: String,
+    val verdi: String,
+)

--- a/src/main/kotlin/no/nav/lydia/tilstandsmaskin/NyFlytService.kt
+++ b/src/main/kotlin/no/nav/lydia/tilstandsmaskin/NyFlytService.kt
@@ -71,11 +71,16 @@ class NyFlytService(
     fun bliEier(
         orgnr: String,
         navAnsatt: NavAnsattMedSaksbehandlerRolle,
+        saksnummer: String? = null, // TODO: fjern nullable etter NyFlytRoutes er slettet
     ): Either<Feil, IASakDto> {
         val aktivSak = hentSisteIASakDto(orgnummer = orgnr)
         if (aktivSak == null || aktivSak.status.regnesSomAvsluttet()) {
             return IASakError.`kan ikke ta eierskap da det ikke finnes noen aktiv sak`.left()
         }
+        if (saksnummer != null && aktivSak.saksnummer != saksnummer) {
+            return Feil(feilmelding = "Saksnummer samsvarer ikke med aktiv sak", httpStatusCode = HttpStatusCode.BadRequest).left()
+        }
+
         if (aktivSak.eidAv == navAnsatt.navIdent) {
             return aktivSak.right()
         }

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
@@ -28,6 +28,7 @@ import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.slettSamarbeidRe
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.verifiserIASakObserversErVarslet
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.verifiserSamarbeidObserversErVarslet
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.vurderVirksomhet
+import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.vurderVirksomhetMedOrgnrResponse
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.vurderVirksomhetResponse
 import no.nav.lydia.helper.PlanHelper
 import no.nav.lydia.helper.PlanHelper.Companion.inkluderEttTemaOgEttInnhold
@@ -772,16 +773,24 @@ class NyFlytTest {
     @Test
     fun `skal ikke kunne vurdere samarbeid med en virksomhet uten å være superbruker`() {
         val orgnummer = VirksomhetHelper.nyttOrgnummer()
-        val res1 = applikasjon.performPost("$NY_FLYT_PATH/$orgnummer/vurder")
-            .authentication().bearer(authContainerHelper.lesebruker.token)
-            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
-            .tilSingelRespons<IASakDto>()
+        val res1 = vurderVirksomhetMedOrgnrResponse(
+            orgnr = orgnummer,
+            token = authContainerHelper.lesebruker.token,
+            valgtÅrsak = ValgtÅrsak(
+                type = ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET,
+                begrunnelser = listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN),
+            ),
+        )
         res1.second.statusCode shouldBe HttpStatusCode.Forbidden.value
 
-        val res2 = applikasjon.performPost("$NY_FLYT_PATH/$orgnummer/vurder")
-            .authentication().bearer(authContainerHelper.saksbehandler1.token)
-            .jsonBody(Json.encodeToString(ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN))))
-            .tilSingelRespons<IASakDto>()
+        val res2 = vurderVirksomhetMedOrgnrResponse(
+            orgnr = orgnummer,
+            token = authContainerHelper.saksbehandler1.token,
+            valgtÅrsak = ValgtÅrsak(
+                type = ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET,
+                begrunnelser = listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN),
+            ),
+        )
         res2.second.statusCode shouldBe HttpStatusCode.Forbidden.value
     }
 

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
@@ -41,7 +41,6 @@ import no.nav.lydia.helper.SakHelper.Companion.leggTilFolger
 import no.nav.lydia.helper.TestContainerHelper.Companion.applikasjon
 import no.nav.lydia.helper.TestContainerHelper.Companion.authContainerHelper
 import no.nav.lydia.helper.TestContainerHelper.Companion.kafkaContainerHelper
-import no.nav.lydia.helper.TestContainerHelper.Companion.performDelete
 import no.nav.lydia.helper.TestContainerHelper.Companion.performPost
 import no.nav.lydia.helper.TestContainerHelper.Companion.performPut
 import no.nav.lydia.helper.TestContainerHelper.Companion.postgresContainerHelper
@@ -68,6 +67,7 @@ import no.nav.lydia.tilstandsmaskin.hendelse.GjørVirksomhetKlarTilNyVurdering
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import kotlin.test.Ignore
 import kotlin.test.Test
 
@@ -1277,7 +1277,7 @@ class NyFlytTest {
         val response = samarbeidSomSkalSlettes.slettSamarbeidRespons(
             orgnr = sak.orgnr,
             token = authContainerHelper.superbruker1.token,
-            dato = LocalDate.now(),
+            dato = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE),
         )
         response.second.statusCode shouldBe HttpStatusCode.BadRequest.value
     }
@@ -1291,9 +1291,11 @@ class NyFlytTest {
         samarbeidSomSkalFullføres.opprettSamarbeidsplan(orgnr = sak.orgnr, planMal = PlanHelper.hentPlanMal())
         samarbeidSomSkalFullføres.avsluttSamarbeid(orgnr = sak.orgnr, avslutningsType = IASamarbeid.Status.FULLFØRT)
 
-        val response = applikasjon.performDelete("$NY_FLYT_PATH/${sak.orgnr}/${samarbeidSomSkalSlettes.id}/slett-samarbeid?dato=tulletekst")
-            .authentication().bearer(authContainerHelper.superbruker1.token)
-            .tilSingelRespons<IASamarbeidDto>()
+        val response = samarbeidSomSkalSlettes.slettSamarbeidRespons(
+            orgnr = sak.orgnr,
+            token = authContainerHelper.superbruker1.token,
+            dato = "tulletekst",
+        )
         response.second.statusCode shouldBe HttpStatusCode.BadRequest.value
     }
 

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
@@ -11,14 +11,14 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldMatch
 import io.ktor.http.HttpStatusCode
 import kotlinx.datetime.toKotlinLocalDate
-import kotlinx.serialization.json.Json
-import no.nav.lydia.api.NY_FLYT_PATH
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.angreVurdering
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttSamarbeid
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttSamarbeidRespons
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttSamarbeidResponsMedDatoString
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttVurdering
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttVurderingResponse
+import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.bliEier
+import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.endrePlanlagtDato
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.endreSamarbeidsNavn
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.hentVirksomhetTilstand
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.hentVirksomhetTilstandResponse
@@ -40,29 +40,23 @@ import no.nav.lydia.helper.SakHelper.Companion.bliEier
 import no.nav.lydia.helper.SakHelper.Companion.bliEierResponse
 import no.nav.lydia.helper.SakHelper.Companion.hentSamarbeidshistorikkNyFlyt
 import no.nav.lydia.helper.SakHelper.Companion.leggTilFolger
-import no.nav.lydia.helper.TestContainerHelper.Companion.applikasjon
 import no.nav.lydia.helper.TestContainerHelper.Companion.authContainerHelper
 import no.nav.lydia.helper.TestContainerHelper.Companion.kafkaContainerHelper
-import no.nav.lydia.helper.TestContainerHelper.Companion.performPost
-import no.nav.lydia.helper.TestContainerHelper.Companion.performPut
 import no.nav.lydia.helper.TestContainerHelper.Companion.postgresContainerHelper
 import no.nav.lydia.helper.TestVirksomhet
 import no.nav.lydia.helper.VirksomhetHelper
 import no.nav.lydia.helper.VirksomhetHelper.Companion.lastInnNyVirksomhet
 import no.nav.lydia.helper.hentAlleSamarbeid
 import no.nav.lydia.helper.statuskode
-import no.nav.lydia.helper.tilSingelRespons
 import no.nav.lydia.prioritering.virksomhet.domene.Næringsgruppe
 import no.nav.lydia.samarbeid.IASamarbeid
 import no.nav.lydia.samarbeidsperiode.BegrunnelseType
 import no.nav.lydia.samarbeidsperiode.IASak
-import no.nav.lydia.samarbeidsperiode.IASakDto
 import no.nav.lydia.samarbeidsperiode.IASakshendelseType
 import no.nav.lydia.samarbeidsperiode.ValgtÅrsak
 import no.nav.lydia.samarbeidsperiode.ÅrsakType
 import no.nav.lydia.tilgangskontroll.fia.Rolle
 import no.nav.lydia.tilstandsmaskin.VirksomhetIATilstand
-import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandAutomatiskOppdateringDto
 import no.nav.lydia.tilstandsmaskin.hendelse.GjørVirksomhetKlarTilNyVurdering
 import org.junit.AfterClass
 import org.junit.BeforeClass
@@ -1365,11 +1359,20 @@ class NyFlytTest {
         val superbruker = authContainerHelper.superbruker1
         val virksomhetUtenSak = VirksomhetHelper.nyttOrgnummer()
 
-        val responseUtenSak = bliEier(orgnr = virksomhetUtenSak, token = superbruker.token)
+        val responseUtenSak = bliEier(
+            orgnr = virksomhetUtenSak,
+            saksnummer = "finnes_ikke",
+            token = superbruker.token,
+        )
         responseUtenSak.statuskode() shouldBe HttpStatusCode.BadRequest.value
 
-        val virksomhetMedAvsluttetSak = vurderVirksomhet().avsluttVurdering().orgnr
-        val responseMedAvsluttetSak = bliEier(orgnr = virksomhetMedAvsluttetSak, superbruker.token)
+        val avsluttetSak = vurderVirksomhet().avsluttVurdering()
+        val virksomhetMedAvsluttetSak = avsluttetSak.orgnr
+        val responseMedAvsluttetSak = bliEier(
+            orgnr = virksomhetMedAvsluttetSak,
+            saksnummer = avsluttetSak.saksnummer,
+            token = superbruker.token,
+        )
         responseMedAvsluttetSak.statuskode() shouldBe HttpStatusCode.BadRequest.value
     }
 
@@ -1381,29 +1384,4 @@ class NyFlytTest {
         val responseLesebruker = sak.bliEierResponse(token = lesebruker.token)
         responseLesebruker.statuskode() shouldBe HttpStatusCode.Forbidden.value
     }
-
-    private fun bliEier(
-        orgnr: String,
-        token: String,
-    ) = applikasjon.performPost("$NY_FLYT_PATH/$orgnr/bli-eier")
-        .authentication().bearer(token = token)
-        .tilSingelRespons<IASakDto>()
-
-    private fun endrePlanlagtDato(
-        orgnr: String,
-        nesteTilstand: VirksomhetTilstandAutomatiskOppdateringDto,
-        nyPlanlagtDato: kotlinx.datetime.LocalDate,
-        token: String = authContainerHelper.saksbehandler1.token,
-    ) = applikasjon.performPut("$NY_FLYT_PATH/virksomhet/$orgnr/endre-planlagt-dato")
-        .authentication().bearer(token)
-        .jsonBody(
-            Json.encodeToString(
-                VirksomhetTilstandAutomatiskOppdateringDto(
-                    startTilstand = nesteTilstand.startTilstand,
-                    planlagtHendelse = nesteTilstand.planlagtHendelse,
-                    nyTilstand = nesteTilstand.nyTilstand,
-                    planlagtDato = nyPlanlagtDato,
-                ),
-            ),
-        ).tilSingelRespons<VirksomhetTilstandAutomatiskOppdateringDto>()
 }

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
@@ -15,6 +15,8 @@ import kotlinx.serialization.json.Json
 import no.nav.lydia.api.NY_FLYT_PATH
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.angreVurdering
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttSamarbeid
+import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttSamarbeidRespons
+import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttSamarbeidResponsMedDatoString
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttVurdering
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttVurderingResponse
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.endreSamarbeidsNavn
@@ -52,14 +54,12 @@ import no.nav.lydia.helper.statuskode
 import no.nav.lydia.helper.tilSingelRespons
 import no.nav.lydia.prioritering.virksomhet.domene.Næringsgruppe
 import no.nav.lydia.samarbeid.IASamarbeid
-import no.nav.lydia.samarbeid.IASamarbeidDto
 import no.nav.lydia.samarbeidsperiode.BegrunnelseType
 import no.nav.lydia.samarbeidsperiode.IASak
 import no.nav.lydia.samarbeidsperiode.IASakDto
 import no.nav.lydia.samarbeidsperiode.IASakshendelseType
 import no.nav.lydia.samarbeidsperiode.ValgtÅrsak
 import no.nav.lydia.samarbeidsperiode.ÅrsakType
-import no.nav.lydia.samarbeidsplan.SamarbeidDto
 import no.nav.lydia.tilgangskontroll.fia.Rolle
 import no.nav.lydia.tilstandsmaskin.VirksomhetIATilstand
 import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandAutomatiskOppdateringDto
@@ -1249,19 +1249,12 @@ class NyFlytTest {
         val samarbeid = sak.opprettSamarbeid()
         samarbeid.opprettSamarbeidsplan(orgnr = sak.orgnr)
 
-        val response = applikasjon.performPost(
-            "$NY_FLYT_PATH/${sak.orgnr}/${samarbeid.id}/avslutt-samarbeid?dato=${LocalDate.now()}",
+        val response = samarbeid.avsluttSamarbeidRespons(
+            orgnr = sak.orgnr,
+            avslutningsType = IASamarbeid.Status.FULLFØRT,
+            token = authContainerHelper.saksbehandler1.token,
+            dato = LocalDate.now(),
         )
-            .authentication().bearer(authContainerHelper.saksbehandler1.token)
-            .jsonBody(
-                Json.encodeToString(
-                    SamarbeidDto(
-                        id = samarbeid.id,
-                        status = IASamarbeid.Status.FULLFØRT,
-                    ),
-                ),
-            )
-            .tilSingelRespons<IASamarbeidDto>()
         response.second.statusCode shouldBe HttpStatusCode.BadRequest.value
     }
 
@@ -1306,17 +1299,13 @@ class NyFlytTest {
         val samarbeid = sak.opprettSamarbeid()
         samarbeid.opprettSamarbeidsplan(orgnr = sak.orgnr)
 
-        val response = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/${samarbeid.id}/avslutt-samarbeid?dato=tulletekst")
-            .authentication().bearer(authContainerHelper.saksbehandler1.token)
-            .jsonBody(
-                Json.encodeToString(
-                    SamarbeidDto(
-                        id = samarbeid.id,
-                        status = IASamarbeid.Status.FULLFØRT,
-                    ),
-                ),
-            )
-            .tilSingelRespons<IASamarbeidDto>()
+        val response = samarbeid.avsluttSamarbeidResponsMedDatoString(
+            orgnr = sak.orgnr,
+            avslutningsType = IASamarbeid.Status.FULLFØRT,
+            token = authContainerHelper.saksbehandler1.token,
+            datoString = "tulletekst",
+        )
+
         response.second.statusCode shouldBe HttpStatusCode.BadRequest.value
     }
 

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
@@ -21,6 +21,7 @@ import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.endreSamarbeidsN
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.hentVirksomhetTilstand
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.hentVirksomhetTilstandResponse
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.opprettSamarbeid
+import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.opprettSamarbeidResponse
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.revurderVirksomhet
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.revurderVirksomhetResponse
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.slettSamarbeid
@@ -1002,17 +1003,10 @@ class NyFlytTest {
 
         val oppdatertSak = sak.leggTilFolger(token = følgerAvSak.token)
         val samarbeidsnavn = "Samarbeid med avdeling A"
-        val samarbeidRespons = applikasjon.performPost("$NY_FLYT_PATH/${sak.orgnr}/opprett-samarbeid")
-            .authentication().bearer(følgerAvSak.token)
-            .jsonBody(
-                Json.encodeToString(
-                    IASamarbeidDto(
-                        id = 0,
-                        saksnummer = oppdatertSak.saksnummer,
-                        navn = samarbeidsnavn,
-                    ),
-                ),
-            ).tilSingelRespons<IASamarbeidDto>()
+        val samarbeidRespons = oppdatertSak.opprettSamarbeidResponse(
+            samarbeidsnavn = samarbeidsnavn,
+            token = følgerAvSak.token,
+        )
 
         samarbeidRespons.second.statusCode shouldBe HttpStatusCode.Created.value
         val samarbeid = samarbeidRespons.third.get()

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTest.kt
@@ -19,6 +19,7 @@ import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttVurdering
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.avsluttVurderingResponse
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.endreSamarbeidsNavn
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.hentVirksomhetTilstand
+import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.hentVirksomhetTilstandResponse
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.opprettSamarbeid
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.revurderVirksomhet
 import no.nav.lydia.container.ny.flyt.NyFlytTestUtils.Companion.revurderVirksomhetResponse
@@ -39,7 +40,6 @@ import no.nav.lydia.helper.TestContainerHelper.Companion.applikasjon
 import no.nav.lydia.helper.TestContainerHelper.Companion.authContainerHelper
 import no.nav.lydia.helper.TestContainerHelper.Companion.kafkaContainerHelper
 import no.nav.lydia.helper.TestContainerHelper.Companion.performDelete
-import no.nav.lydia.helper.TestContainerHelper.Companion.performGet
 import no.nav.lydia.helper.TestContainerHelper.Companion.performPost
 import no.nav.lydia.helper.TestContainerHelper.Companion.performPut
 import no.nav.lydia.helper.TestContainerHelper.Companion.postgresContainerHelper
@@ -62,7 +62,6 @@ import no.nav.lydia.samarbeidsplan.SamarbeidDto
 import no.nav.lydia.tilgangskontroll.fia.Rolle
 import no.nav.lydia.tilstandsmaskin.VirksomhetIATilstand
 import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandAutomatiskOppdateringDto
-import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandDto
 import no.nav.lydia.tilstandsmaskin.hendelse.GjørVirksomhetKlarTilNyVurdering
 import org.junit.AfterClass
 import org.junit.BeforeClass
@@ -93,9 +92,7 @@ class NyFlytTest {
         )
         lastInnNyVirksomhet(virksomhet)
 
-        val response = applikasjon.performGet("$NY_FLYT_PATH/${virksomhet.orgnr}/tilstand")
-            .authentication().bearer(authContainerHelper.saksbehandler1.token)
-            .tilSingelRespons<VirksomhetTilstandDto>()
+        val response = hentVirksomhetTilstandResponse(orgnr = virksomhet.orgnr, token = authContainerHelper.saksbehandler1.token)
 
         response.statuskode() shouldBe HttpStatusCode.OK.value
         val virksomhetTilstandDto = response.third.get()
@@ -108,9 +105,7 @@ class NyFlytTest {
     fun `hent tilstand for virksomhet som ikke finnes returnerer 404`() {
         val orgnrSomIkkeFinnes = "999888777"
 
-        val response = applikasjon.performGet("$NY_FLYT_PATH/$orgnrSomIkkeFinnes/tilstand")
-            .authentication().bearer(authContainerHelper.saksbehandler1.token)
-            .tilSingelRespons<VirksomhetTilstandDto>()
+        val response = hentVirksomhetTilstandResponse(orgnr = orgnrSomIkkeFinnes, token = authContainerHelper.saksbehandler1.token)
 
         response.statuskode() shouldBe HttpStatusCode.NotFound.value
     }

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -33,6 +33,7 @@ import no.nav.lydia.helper.TestContainerHelper.Companion.performDelete
 import no.nav.lydia.helper.TestContainerHelper.Companion.performGet
 import no.nav.lydia.helper.TestContainerHelper.Companion.performPost
 import no.nav.lydia.helper.TestContainerHelper.Companion.performPut
+import no.nav.lydia.helper.TestResponseTriple
 import no.nav.lydia.helper.TestVirksomhet
 import no.nav.lydia.helper.VirksomhetHelper.Companion.lastInnNyVirksomhet
 import no.nav.lydia.helper.forExactlyOne
@@ -119,9 +120,18 @@ class NyFlytTestUtils {
             orgnr: String,
             token: String = authContainerHelper.superbruker1.token,
         ): VirksomhetTilstandDto {
-            val url = "$NY_FLYT_PATH/$orgnr/tilstand"
+            val url = "$NY_FLYT_API_PATH/virksomhet/$orgnr/tilstand"
             return applikasjon.performGet(url)
                 .authentication().bearer(token).tilSingelRespons<VirksomhetTilstandDto>().third.get()
+        }
+
+        fun hentVirksomhetTilstandResponse(
+            orgnr: String,
+            token: String = authContainerHelper.superbruker1.token,
+        ): TestResponseTriple<VirksomhetTilstandDto> {
+            val url = "$NY_FLYT_API_PATH/virksomhet/$orgnr/tilstand"
+            return applikasjon.performGet(url)
+                .authentication().bearer(token).tilSingelRespons<VirksomhetTilstandDto>()
         }
 
         fun verifiserKafkaPlanObserversErVarslet(
@@ -432,7 +442,7 @@ class NyFlytTestUtils {
                 Json.encodeToString(endringer),
             ).tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
-                failure = { fail("${it.message}") },
+                failure = { fail(it.message) },
             )
 
         fun IASamarbeidDto.oppdaterTemaISamarbeidsplan(
@@ -449,7 +459,7 @@ class NyFlytTestUtils {
                 Json.encodeToString(endringer),
             ).tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
-                failure = { fail("${it.message}") },
+                failure = { fail(it.message) },
             )
 
         fun IASamarbeidDto.slettSamarbeidRespons(
@@ -499,7 +509,7 @@ class NyFlytTestUtils {
                 Json.encodeToString(nyStatus),
             ).tilSingelRespons<PlanDto>().third.fold(
                 success = { respons -> respons },
-                failure = { fail("${it.message}") },
+                failure = { fail(it.message) },
             )
 
         fun PlanDto.endreTema(

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -111,7 +111,7 @@ class NyFlytTestUtils {
             orgnr: String,
             token: String = authContainerHelper.superbruker1.token,
         ): VirksomhetDto {
-            val url = "$NY_FLYT_PATH/virksomhet/$orgnr"
+            val url = "$NY_FLYT_API_PATH/virksomhet/$orgnr"
             return applikasjon.performGet(url)
                 .authentication().bearer(token).tilSingelRespons<VirksomhetDto>().third.get()
         }

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -389,7 +389,7 @@ class NyFlytTestUtils {
         fun IASakDto.opprettSamarbeidResponse(
             token: String = authContainerHelper.saksbehandler1.token,
             samarbeidsnavn: String = "Samarbeid med $orgnr",
-        ) = applikasjon.performPost("$NY_FLYT_API_PATH/virksomhet/$orgnr/opprett-samarbeid")
+        ) = applikasjon.performPost("$NY_FLYT_API_PATH/virksomhet/$orgnr/samarbeidsperiode/$saksnummer/samarbeid")
             .authentication().bearer(token)
             .jsonBody(
                 Json.encodeToString(

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -291,7 +291,7 @@ class NyFlytTestUtils {
                 ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET,
                 listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN),
             ),
-        ) = revurderVirksomhetResponse().third.fold(
+        ) = revurderVirksomhetResponse(token = token, valgtÅrsak = valgtÅrsak).third.fold(
             success = { it },
             failure = { fail(it.message) },
         )

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -389,7 +389,7 @@ class NyFlytTestUtils {
         fun IASakDto.opprettSamarbeidResponse(
             token: String = authContainerHelper.saksbehandler1.token,
             samarbeidsnavn: String = "Samarbeid med $orgnr",
-        ) = applikasjon.performPost("$NY_FLYT_PATH/$orgnr/opprett-samarbeid")
+        ) = applikasjon.performPost("$NY_FLYT_API_PATH/virksomhet/$orgnr/opprett-samarbeid")
             .authentication().bearer(token)
             .jsonBody(
                 Json.encodeToString(

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -246,11 +246,11 @@ class NyFlytTestUtils {
             }
         }
 
-        private fun vurderVirksomhetMedOrgnrResponse(
+        fun vurderVirksomhetMedOrgnrResponse(
             orgnr: String,
             token: String = authContainerHelper.superbruker1.token,
             valgtÅrsak: ValgtÅrsak = ValgtÅrsak(ÅrsakType.BAKGRUNN_FOR_VURDERING_AV_VIRKSOMHET, listOf(BegrunnelseType.NAV_VURDERER_VIRKSOMHETEN)),
-        ) = applikasjon.performPost("$NY_FLYT_PATH/$orgnr/vurder")
+        ) = applikasjon.performPost("$NY_FLYT_API_PATH/virksomhet/$orgnr/vurder")
             .authentication().bearer(token)
             .jsonBody(Json.encodeToString(valgtÅrsak))
             .tilSingelRespons<IASakDto>()

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -465,8 +465,15 @@ class NyFlytTestUtils {
         fun IASamarbeidDto.slettSamarbeidRespons(
             orgnr: String,
             token: String = authContainerHelper.saksbehandler1.token,
-            dato: java.time.LocalDate? = null,
-        ) = applikasjon.performDelete("$NY_FLYT_PATH/$orgnr/${this.id}/slett-samarbeid" + (dato?.let { "?dato=$it" } ?: ""))
+            dato: String? = null,
+        ) = applikasjon.performDelete(
+            "$NY_FLYT_API_PATH/virksomhet/$orgnr/samarbeidsperiode/${this.saksnummer}/samarbeid/${this.id}" + (
+                dato?.let {
+                    "?dato=$it"
+                }
+                    ?: ""
+            ),
+        )
             .authentication().bearer(token)
             .tilSingelRespons<IASamarbeidDto>()
 
@@ -477,7 +484,7 @@ class NyFlytTestUtils {
         ) = this.slettSamarbeidRespons(
             orgnr = orgnr,
             token = token,
-            dato = dato,
+            dato = dato?.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE),
         ).third.fold(
             success = { respons -> respons },
             failure = { fail(it.message) },

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -61,6 +61,7 @@ import no.nav.lydia.samarbeidsplan.SamarbeidDto
 import no.nav.lydia.samarbeidsplan.SamarbeidsplanBigqueryProdusent.InnholdIPlanMelding
 import no.nav.lydia.samarbeidsplan.SamarbeidsplanKafkaMelding
 import no.nav.lydia.tilgangskontroll.fia.Rolle
+import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandAutomatiskOppdateringDto
 import no.nav.lydia.tilstandsmaskin.VirksomhetTilstandDto
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import kotlin.test.fail
@@ -366,6 +367,32 @@ class NyFlytTestUtils {
             { it },
             { fail("${it.message}: ${it.response.body().asString("text/plain; charset=utf-8")}") },
         )
+
+        fun bliEier(
+            orgnr: String,
+            saksnummer: String,
+            token: String,
+        ) = applikasjon.performPost("$NY_FLYT_API_PATH/virksomhet/$orgnr/samarbeidsperiode/$saksnummer/bli-eier")
+            .authentication().bearer(token = token)
+            .tilSingelRespons<IASakDto>()
+
+        fun endrePlanlagtDato(
+            orgnr: String,
+            nesteTilstand: VirksomhetTilstandAutomatiskOppdateringDto,
+            nyPlanlagtDato: LocalDate,
+            token: String = authContainerHelper.saksbehandler1.token,
+        ) = applikasjon.performPut("$NY_FLYT_API_PATH/virksomhet/$orgnr/endre-planlagt-dato")
+            .authentication().bearer(token)
+            .jsonBody(
+                Json.encodeToString(
+                    VirksomhetTilstandAutomatiskOppdateringDto(
+                        startTilstand = nesteTilstand.startTilstand,
+                        planlagtHendelse = nesteTilstand.planlagtHendelse,
+                        nyTilstand = nesteTilstand.nyTilstand,
+                        planlagtDato = nyPlanlagtDato,
+                    ),
+                ),
+            ).tilSingelRespons<VirksomhetTilstandAutomatiskOppdateringDto>()
 
         fun IASamarbeidDto.avsluttSamarbeidResponsMedDatoString(
             orgnr: String,

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -16,7 +16,6 @@ import kotlinx.datetime.todayIn
 import kotlinx.serialization.json.Json
 import no.nav.lydia.Topic
 import no.nav.lydia.api.NY_FLYT_API_PATH
-import no.nav.lydia.api.NY_FLYT_PATH
 import no.nav.lydia.container.ia.eksport.IASakStatistikkEksportererTest.Companion.hentFraKvartal
 import no.nav.lydia.container.ia.eksport.IASakStatistikkEksportererTest.Companion.hentFraSiste4Kvartaler
 import no.nav.lydia.container.ia.eksport.SamarbeidsplanBigqueryEksportererTest.Companion.inkludertInnhold
@@ -31,6 +30,7 @@ import no.nav.lydia.helper.TestContainerHelper.Companion.authContainerHelper
 import no.nav.lydia.helper.TestContainerHelper.Companion.kafkaContainerHelper
 import no.nav.lydia.helper.TestContainerHelper.Companion.performDelete
 import no.nav.lydia.helper.TestContainerHelper.Companion.performGet
+import no.nav.lydia.helper.TestContainerHelper.Companion.performPatch
 import no.nav.lydia.helper.TestContainerHelper.Companion.performPost
 import no.nav.lydia.helper.TestContainerHelper.Companion.performPut
 import no.nav.lydia.helper.TestResponseTriple
@@ -41,6 +41,7 @@ import no.nav.lydia.helper.hentAlleSamarbeid
 import no.nav.lydia.helper.statuskode
 import no.nav.lydia.helper.tilSingelRespons
 import no.nav.lydia.prioritering.virksomhet.VirksomhetDto
+import no.nav.lydia.samarbeid.EndringISamarbeidDto
 import no.nav.lydia.samarbeid.IASamarbeid
 import no.nav.lydia.samarbeid.IASamarbeidDto
 import no.nav.lydia.samarbeid.SamarbeidBigqueryProdusent.SamarbeidValue
@@ -366,12 +367,15 @@ class NyFlytTestUtils {
             { fail("${it.message}: ${it.response.body().asString("text/plain; charset=utf-8")}") },
         )
 
-        fun IASamarbeidDto.avsluttSamarbeid(
+        fun IASamarbeidDto.avsluttSamarbeidResponsMedDatoString(
             orgnr: String,
             avslutningsType: IASamarbeid.Status,
             token: String = authContainerHelper.saksbehandler1.token,
-            dato: java.time.LocalDate? = null,
-        ) = applikasjon.performPost("$NY_FLYT_PATH/$orgnr/${this.id}/avslutt-samarbeid" + (dato?.let { "?dato=$it" } ?: ""))
+            datoString: String,
+        ) = applikasjon.performPost(
+            "$NY_FLYT_API_PATH/virksomhet/$orgnr/samarbeidsperiode/$saksnummer/samarbeid/${this.id}" +
+                medDatoParameterHvisNotNull(datoString),
+        )
             .authentication().bearer(token)
             .jsonBody(
                 Json.encodeToString(
@@ -381,10 +385,42 @@ class NyFlytTestUtils {
                     ),
                 ),
             )
-            .tilSingelRespons<IASamarbeidDto>().third.fold(
-                success = { respons -> respons },
-                failure = { fail(it.message) },
+            .tilSingelRespons<IASamarbeidDto>()
+
+        fun IASamarbeidDto.avsluttSamarbeidRespons(
+            orgnr: String,
+            avslutningsType: IASamarbeid.Status,
+            token: String = authContainerHelper.saksbehandler1.token,
+            dato: java.time.LocalDate? = null,
+        ) = applikasjon.performPost(
+            "$NY_FLYT_API_PATH/virksomhet/$orgnr/samarbeidsperiode/$saksnummer/samarbeid/${this.id}" +
+                medDatoParameterHvisNotNull(dato?.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE)),
+        )
+            .authentication().bearer(token)
+            .jsonBody(
+                Json.encodeToString(
+                    SamarbeidDto(
+                        id = this.id,
+                        status = avslutningsType,
+                    ),
+                ),
             )
+            .tilSingelRespons<IASamarbeidDto>()
+
+        fun IASamarbeidDto.avsluttSamarbeid(
+            orgnr: String,
+            avslutningsType: IASamarbeid.Status,
+            token: String = authContainerHelper.saksbehandler1.token,
+            dato: java.time.LocalDate? = null,
+        ) = this.avsluttSamarbeidRespons(
+            orgnr = orgnr,
+            avslutningsType = avslutningsType,
+            token = token,
+            dato = dato,
+        ).third.fold(
+            success = { respons -> respons },
+            failure = { fail(it.message) },
+        )
 
         fun IASakDto.opprettSamarbeidResponse(
             token: String = authContainerHelper.saksbehandler1.token,
@@ -414,14 +450,13 @@ class NyFlytTestUtils {
             orgnr: String,
             nyttNavn: String,
             token: String = authContainerHelper.saksbehandler1.token,
-        ) = applikasjon.performPut("$NY_FLYT_PATH/virksomhet/$orgnr/samarbeid/$id/oppdater")
+        ) = applikasjon.performPatch("${NY_FLYT_API_PATH}/virksomhet/$orgnr/samarbeidsperiode/$saksnummer/samarbeid/$id")
             .authentication().bearer(token)
             .jsonBody(
                 Json.encodeToString(
-                    IASamarbeidDto(
-                        id = id,
-                        saksnummer = saksnummer,
-                        navn = nyttNavn,
+                    EndringISamarbeidDto(
+                        typeEndring = "navn",
+                        verdi = nyttNavn,
                     ),
                 ),
             ).tilSingelRespons<IASamarbeidDto>().third.fold(
@@ -467,12 +502,8 @@ class NyFlytTestUtils {
             token: String = authContainerHelper.saksbehandler1.token,
             dato: String? = null,
         ) = applikasjon.performDelete(
-            "$NY_FLYT_API_PATH/virksomhet/$orgnr/samarbeidsperiode/${this.saksnummer}/samarbeid/${this.id}" + (
-                dato?.let {
-                    "?dato=$it"
-                }
-                    ?: ""
-            ),
+            "$NY_FLYT_API_PATH/virksomhet/$orgnr/samarbeidsperiode/${this.saksnummer}/samarbeid/${this.id}" +
+                medDatoParameterHvisNotNull(dato),
         )
             .authentication().bearer(token)
             .tilSingelRespons<IASamarbeidDto>()
@@ -543,6 +574,14 @@ class NyFlytTestUtils {
                         tema
                     }
                 },
+            )
+
+        private fun medDatoParameterHvisNotNull(dato: String?): String =
+            (
+                dato?.let {
+                    "?dato=$it"
+                }
+                    ?: ""
             )
     }
 }

--- a/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
+++ b/src/test/kotlin/no/nav/lydia/container/ny/flyt/NyFlytTestUtils.kt
@@ -297,7 +297,7 @@ class NyFlytTestUtils {
         )
 
         fun IASakDto.angreVurdering(token: String = authContainerHelper.superbruker1.token) =
-            applikasjon.performPost("$NY_FLYT_PATH/$orgnr/angre-vurdering")
+            applikasjon.performPost("$NY_FLYT_API_PATH/virksomhet/$orgnr/angre-vurdering")
                 .authentication().bearer(token)
                 .tilSingelRespons<IASakDto>().third.fold(
                     success = { it },

--- a/src/test/kotlin/no/nav/lydia/helper/SakHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/SakHelper.kt
@@ -99,7 +99,7 @@ class SakHelper {
             orgnummer: String,
             token: String = TestContainerHelper.authContainerHelper.saksbehandler1.token,
         ): TestResponseTriple<List<SakshistorikkDto>> {
-            val url = "${NY_FLYT_PATH}/virksomhet/$orgnummer/historikk"
+            val url = "${NY_FLYT_API_PATH}/virksomhet/$orgnummer/historikk"
             return TestContainerHelper.applikasjon.performGet(url)
                 .authentication().bearer(token = token)
                 .tilListeRespons<SakshistorikkDto>()

--- a/src/test/kotlin/no/nav/lydia/helper/SakHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/SakHelper.kt
@@ -5,7 +5,6 @@ import no.nav.lydia.api.IA_SAK_LEVERANSE_PATH
 import no.nav.lydia.api.IA_SAK_RADGIVER_PATH
 import no.nav.lydia.api.IA_SAK_TEAM_PATH
 import no.nav.lydia.api.NY_FLYT_API_PATH
-import no.nav.lydia.api.NY_FLYT_PATH
 import no.nav.lydia.api.SAMARBEIDSHISTORIKK_PATH
 import no.nav.lydia.helper.TestContainerHelper.Companion.performGet
 import no.nav.lydia.helper.TestContainerHelper.Companion.performPost
@@ -32,7 +31,7 @@ class SakHelper {
             .also { it.saksnummer shouldBe saksnummer }
 
         fun IASakDto.bliEierResponse(token: String) =
-            TestContainerHelper.applikasjon.performPost("${NY_FLYT_PATH}/$orgnr/bli-eier")
+            TestContainerHelper.applikasjon.performPost("${NY_FLYT_API_PATH}/virksomhet/$orgnr/samarbeidsperiode/$saksnummer/bli-eier")
                 .authentication().bearer(token = token)
                 .tilSingelRespons<IASakDto>()
 

--- a/src/test/kotlin/no/nav/lydia/helper/SakHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/SakHelper.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.lydia.api.IA_SAK_LEVERANSE_PATH
 import no.nav.lydia.api.IA_SAK_RADGIVER_PATH
 import no.nav.lydia.api.IA_SAK_TEAM_PATH
+import no.nav.lydia.api.NY_FLYT_API_PATH
 import no.nav.lydia.api.NY_FLYT_PATH
 import no.nav.lydia.api.SAMARBEIDSHISTORIKK_PATH
 import no.nav.lydia.helper.TestContainerHelper.Companion.performGet
@@ -70,7 +71,7 @@ class SakHelper {
             token: String = TestContainerHelper.authContainerHelper.saksbehandler1.token,
         ): IASakDto {
             val triple = TestContainerHelper.applikasjon.performGet(
-                "${NY_FLYT_PATH}/virksomhet/$orgnummer/samarbeidsperiode${saksnummer?.let {
+                "${NY_FLYT_API_PATH}/virksomhet/$orgnummer/samarbeidsperiode${saksnummer?.let {
                     "/$it"
                 } ?: ""}",
             )

--- a/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/lydia/helper/TestContainerHelper.kt
@@ -168,6 +168,8 @@ class TestContainerHelper {
 
         fun GenericContainer<*>.performPut(url: String) = TestRequest(HttpMethod.Put, buildUrl(url))
 
+        fun GenericContainer<*>.performPatch(url: String) = TestRequest(HttpMethod.Patch, buildUrl(url))
+
         infix fun GenericContainer<*>.shouldContainLog(regex: Regex) = logs shouldContain regex
 
         infix fun GenericContainer<*>.shouldNotContainLog(regex: Regex) = logs shouldNotContain regex


### PR DESCRIPTION
Refactor: flytter og forbedrer noen 'ny flyt' endepunkter. 

Ønsket forbedringer:
 - mer RESTfull api (ordentlig path til ressurs, bruk av riktig Http verb) 
 - bli kvitt 'ny flyt' i URL 
 - bruk av 'api' root URL 

Gjelder følgende endepunkter, per område/ressurs

**Virksomhet** 
 - GET `/api/v1/virksomhet/{orgnummer}` (hent virksomhet)
 - GET `/api/v1/virksomhet/{orgnummer}/historikk` (hent historikk)
 - GET `/api/v1/virksomhet/{orgnummer}/tilstand` (hent tilstand til en virksomhet)
 - PUT `/api/v1/virksomhet/{orgnummer}/endre-planlagt-dato` (endre planlagt dato til neste tilstand)
 - POST `/api/v1/virksomhet/{orgnummer}/vurder` (vurder virksomhet)
 - POST `/api/v1/virksomhet/{orgnummer}/angre-vurdering` (angre vurdering)

**Samarbeidsperiode** 
 - GET `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode` (hent aktiv samarbeidsperiode - tidl. IASak )
 - GET `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}` (hent samarbeidsperiode - tidl. IASak )
 - POST `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/bli-eier` (bli eier)

**Samarbeid** 
 - POST `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid` (opprett samarbeid)
 - PATCH `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}` (oppdater navn på samarbeid)
 - POST `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}` (avslutt samarbeid)
 - DELETE `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/${saksnummer}/samarbeid/{samarbeidId}` (slett samarbeid)
 